### PR TITLE
[WIP] Experimental test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,89 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/examples/python3-urllib/run.py
+++ b/examples/python3-urllib/run.py
@@ -1,0 +1,17 @@
+import sys
+import ssl
+import urllib.error
+import urllib.request
+
+host = sys.argv[1]
+port = sys.argv[2]
+cafile = sys.argv[3] if len(sys.argv) > 3 else None
+
+try:
+    urllib.request.urlopen("https://" + host + ":" + port, cafile=cafile)
+except urllib.error.URLError as exc:
+    if not isinstance(exc.reason, ssl.SSLError):
+        raise
+    print("FAIL")
+else:
+    print("OK")

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
 from setuptools import setup, find_packages
 
+print(find_packages())
+
 setup(
     name="trytls",
-    version="0.0.1",
-    packages=find_packages("showrunner")
+    version="0.0.2",
+    packages=find_packages(),
+    entry_points={
+        "console_scripts": ["trytls=showrunner.runner:main"]
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="trytls",
+    version="0.0.1",
+    packages=find_packages("showrunner")
+)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 from setuptools import setup, find_packages
 
-print(find_packages())
-
 setup(
     name="trytls",
     version="0.0.2",

--- a/showrunner/__init__.py
+++ b/showrunner/__init__.py
@@ -1,0 +1,3 @@
+from .testenv import testenv
+
+__all__ = ["testenv"]

--- a/showrunner/runner.py
+++ b/showrunner/runner.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-import sys
 import subprocess
 
 
@@ -45,9 +44,24 @@ def run(args, tests):
 
 
 def main():
+    import argparse
     from .testenv import badssl
 
-    run(sys.argv[1:], [
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "command",
+        metavar="COMMAND",
+        help="the command to run"
+    )
+    parser.add_argument(
+        "args",
+        metavar="ARG",
+        nargs="*",
+        help="additional argument for the command"
+    )
+    args = parser.parse_args()
+
+    run([args.command] + args.args, [
         badssl(True, "sha1-2016"),
         badssl(False, "expired")
     ])

--- a/showrunner/runner.py
+++ b/showrunner/runner.py
@@ -1,0 +1,53 @@
+from __future__ import print_function
+
+import sys
+import subprocess
+
+
+class ProcessFailed(Exception):
+    pass
+
+
+class UnexpectedOutput(Exception):
+    pass
+
+
+def run_one(args, host, port, ca_cert=None):
+    args = args + [host, str(port)]
+    if ca_cert is not None:
+        args.append(ca_cert)
+
+    process = subprocess.Popen(
+        args,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE
+    )
+    stdout, _ = process.communicate()
+
+    if process.returncode != 0:
+        raise ProcessFailed()
+
+    if stdout.strip() == "OK":
+        return True
+    if stdout.strip() == "FAIL":
+        return False
+    raise UnexpectedOutput()
+
+
+def run(args, tests):
+    for test in tests:
+        with test() as (ok_expected, host, port, ca_cert):
+            ok = run_one(list(args), host, port, ca_cert)
+            if bool(ok) == bool(ok_expected):
+                print("PASS", test)
+            else:
+                print("ERROR", test)
+
+
+def main():
+    from .testenv import badssl
+
+    run(sys.argv[1:], [
+        badssl(True, "sha1-2016"),
+        badssl(False, "expired")
+    ])

--- a/showrunner/testenv.py
+++ b/showrunner/testenv.py
@@ -1,0 +1,37 @@
+import contextlib
+
+
+class _TestEnv(object):
+    def __init__(self, func, args, kwargs):
+        self._func = func
+        self._args = args
+        self._kwargs = kwargs
+
+    def __repr__(self):
+        """
+        >>> def mytest(a, b):
+        ...     pass
+        >>> repr(_TestEnv(mytest, [1], {"b": 2}))
+        'mytest(1, b=2)'
+        """
+
+        params = []
+        if self._args:
+            params.extend("{v!r}".format(v=v) for v in self._args)
+        if self._kwargs:
+            params.extend("{k}={v!r}".format(k=k, v=v) for (k, v) in self._kwargs.items())
+        return "{name}({params})".format(name=self._func.__name__, params=", ".join(params))
+
+    def __call__(self):
+        return contextlib.contextmanager(self._func)(*self._args, **self._kwargs)
+
+
+def testenv(func):
+    def _testenv(*args, **keys):
+        return _TestEnv(func, args, keys)
+    return _testenv
+
+
+@testenv
+def badssl(ok_expected, name):
+    yield ok_expected, name + ".badssl.com", 443, None

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = flake8
+
+[testenv:flake8]
+deps = flake8
+commands = flake8
+
+[flake8]
+ignore = E501
+filename = showrunner

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,16 @@
 [tox]
-envlist = flake8
+envlist = py27,py35
 
-[testenv:flake8]
-deps = flake8
-commands = flake8
+[testenv]
+deps =
+  flake8
+  pytest
+commands =
+  flake8 showrunner
+  py.test showrunner
+
+[pytest]
+addopts = --doctest-modules
 
 [flake8]
 ignore = E501
-filename = showrunner


### PR DESCRIPTION
This pull request adds an experimental `trytls` test runner. To test an imaginary executable `mytest` you can run it like so:

``` console
$ trytls mytest
```

`trytls` then runs `mytest` several times, every time with 2 or 3 arguments (`HOST PORT [CA_BUNDLE]`). `HOST` and `PORT` are the host:port pair `mytest` should connect to. The optional `CA_BUNDLE` argument points to a custom CA bundle `mytest` should use for verifying the certificates it encounters. If it's not given then `mytest` should use its default CA bundle, if any.
#### Todo
- [x] Add basic Python package scaffolding
  - [x] Configure `tox` & `flake8`
- [x] Add `trytls` command line tool for running testers
- [x] Add [badssl.com](https://badssl.com/) tests
- [ ] Add locally served tests
- [x] Add a HTTP tester example
- [ ] Add a non-HTTP tester example
- [ ] Add a non-Python tester example
