### PR TITLE
Experimental test runner (part 2)

### DIFF
--- a/examples/python3-imaplib/run.py
+++ b/examples/python3-imaplib/run.py
@@ -1,0 +1,19 @@
+import sys
+import ssl
+import imaplib
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+cafile = sys.argv[3] if len(sys.argv) > 3 else None
+
+if cafile is None:
+    ssl_context = ssl.create_default_context()
+else:
+    ssl_context = ssl.create_default_context(cafile=cafile)
+
+try:
+    imaplib.IMAP4_SSL(host, port, ssl_context=ssl_context)
+except (ssl.SSLError, ssl.CertificateError):
+    print("FAIL")
+else:
+    print("OK")

--- a/examples/python3-urllib/run.py
+++ b/examples/python3-urllib/run.py
@@ -9,6 +9,8 @@ cafile = sys.argv[3] if len(sys.argv) > 3 else None
 
 try:
     urllib.request.urlopen("https://" + host + ":" + port, cafile=cafile)
+except ssl.CertificateError:
+    print("FAIL")
 except urllib.error.URLError as exc:
     if not isinstance(exc.reason, ssl.SSLError):
         raise

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="trytls",
-    version="0.0.2",
+    version="0.0.3",
     packages=find_packages(),
     entry_points={
         "console_scripts": ["trytls=showrunner.runner:main"]

--- a/showrunner/bundles/handshake.py
+++ b/showrunner/bundles/handshake.py
@@ -1,0 +1,16 @@
+from ..testenv import badssl, local
+
+
+badssl_tests = [
+    badssl(True, "sha1-2016"),
+    badssl(False, "expired")
+]
+
+
+local_tests = [
+    local(True, "localhost"),
+    local(False, "nothing")
+]
+
+
+all_tests = badssl_tests + local_tests

--- a/showrunner/bundles/https.py
+++ b/showrunner/bundles/https.py
@@ -1,0 +1,26 @@
+import ssl
+import functools
+from ..testenv import badssl, local as _local
+
+
+def https_callback(conn, certfile, keyfile):
+    s = ssl.wrap_socket(conn, server_side=True, certfile=certfile, keyfile=keyfile)
+    s.sendall(b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n")
+
+
+local = functools.partial(_local, callback=https_callback)
+
+
+badssl_tests = [
+    badssl(True, "sha1-2016"),
+    badssl(False, "expired")
+]
+
+
+local_tests = [
+    local(True, "localhost"),
+    local(False, "nothing")
+]
+
+
+all_tests = badssl_tests + local_tests

--- a/showrunner/bundles/imap.py
+++ b/showrunner/bundles/imap.py
@@ -1,0 +1,23 @@
+import socket
+from ..testenv import testenv
+
+
+@testenv
+def gmail():
+    yield True, "imap.gmail.com", 993, None
+
+
+@testenv
+def gmail_fail():
+    for (_, _, _, _, (host, port)) in socket.getaddrinfo("imap.gmail.com", 993):
+        yield False, host, port, None
+        break
+
+
+gmail_tests = [
+    gmail(),
+    gmail_fail()
+]
+
+
+all_tests = gmail_tests

--- a/showrunner/gencert.py
+++ b/showrunner/gencert.py
@@ -1,0 +1,48 @@
+import subprocess
+from .utils import tmpfiles, memoized
+
+
+def openssl(args, input=None):
+    process = subprocess.Popen(
+        ["openssl"] + list(args),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+    stdout, _ = process.communicate(input)
+    if process.returncode != 0:
+        raise RuntimeError()
+    return stdout
+
+
+@memoized
+def _ca_key():
+    return openssl(["genrsa", "4096"])
+
+
+@memoized
+def _cert_key():
+    return openssl(["genrsa", "4096"])
+
+
+def gencert(cn):
+    subj = "/CN=" + cn
+    ca_key = _ca_key()
+    cert_key = _cert_key()
+
+    # Generate the CA
+    with tmpfiles(ca_key) as ca_keyfile:
+        ca_data = openssl(["req", "-new", "-key", ca_keyfile, "-x509", "-subj", "/"])
+
+    # Generate a certificate signing request
+    with tmpfiles(cert_key) as cert_keyfile:
+        cert_csr = openssl(["req", "-new", "-subj", subj, "-key", cert_keyfile])
+
+    # Sign the certificate with the CA
+    with tmpfiles(ca_key, ca_data) as (ca_keyfile, ca_file):
+        cert_data = openssl(
+            ["x509", "-req", "-CA", ca_file, "-CAkey", ca_keyfile, "-set_serial", "01"],
+            input=cert_csr
+        )
+
+    return cert_data, cert_key, ca_data

--- a/showrunner/runner.py
+++ b/showrunner/runner.py
@@ -12,10 +12,10 @@ class UnexpectedOutput(Exception):
     pass
 
 
-def run_one(args, host, port, ca_cert=None):
+def run_one(args, host, port, cafile=None):
     args = args + [host, str(port)]
-    if ca_cert is not None:
-        args.append(ca_cert)
+    if cafile is not None:
+        args.append(cafile)
 
     process = subprocess.Popen(
         args,
@@ -37,9 +37,9 @@ def run_one(args, host, port, ca_cert=None):
 
 def run(args, tests):
     for test in tests:
-        with test() as (ok_expected, host, port, ca_cert):
+        with test() as (ok_expected, host, port, cafile):
             try:
-                ok = run_one(list(args), host, port, ca_cert)
+                ok = run_one(list(args), host, port, cafile)
             except UnexpectedOutput as uo:
                 output = uo.args[0].decode("ascii", "backslashreplace")
                 print("ERROR unexpected output:\n{}".format(textwrap.indent(output, " " * 4)))
@@ -54,7 +54,7 @@ def run(args, tests):
 
 def main():
     import argparse
-    from .testenv import badssl
+    from .testenv import badssl, local
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -72,5 +72,7 @@ def main():
 
     run([args.command] + args.args, [
         badssl(True, "sha1-2016"),
-        badssl(False, "expired")
+        badssl(False, "expired"),
+        local(True, "localhost"),
+        local(False, "nothing")
     ])

--- a/showrunner/runner.py
+++ b/showrunner/runner.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import argparse
-import textwrap
 import importlib
 import subprocess
 
@@ -14,6 +13,16 @@ class ProcessFailed(Exception):
 
 class UnexpectedOutput(Exception):
     pass
+
+
+def indent(text, indent):
+    r"""
+    >>> indent("a\nb\nc", indent="    ")
+    '    a\n    b\n    c'
+    """
+
+    lines = text.splitlines(True)
+    return "".join(indent + line for line in lines)
 
 
 def run_one(args, host, port, cafile=None):
@@ -46,7 +55,7 @@ def run(args, tests):
                 ok = run_one(list(args), host, port, cafile)
             except UnexpectedOutput as uo:
                 output = uo.args[0].decode("ascii", "backslashreplace")
-                print("ERROR unexpected output:\n{}".format(textwrap.indent(output, " " * 4)))
+                print("ERROR unexpected output:\n{}".format(indent(output, " " * 4)))
             except ProcessFailed as pf:
                 print("ERROR process exited with return code {}".format(pf.args[0]))
             else:
@@ -59,7 +68,7 @@ def run(args, tests):
 def module_path(string):
     string = string.strip()
     if string.startswith("."):
-        string = bundles.__package__ + string
+        string = bundles.__name__ + string
 
     pieces = string.split(".")
     name = pieces.pop()
@@ -99,3 +108,7 @@ def main():
     args = parser.parse_args()
 
     run([args.command] + args.args, args.test_bundle)
+
+
+if __name__ == "__main__":
+    main()

--- a/showrunner/testenv.py
+++ b/showrunner/testenv.py
@@ -45,17 +45,12 @@ def badssl(ok_expected, name):
     yield ok_expected, name + ".badssl.com", 443, None
 
 
-def raw_callback(conn, certfile, keyfile):
+def handshake_callback(conn, certfile, keyfile):
     ssl.wrap_socket(conn, server_side=True, certfile=certfile, keyfile=keyfile)
 
 
-def https_callback(conn, certfile, keyfile):
-    s = ssl.wrap_socket(conn, server_side=True, certfile=certfile, keyfile=keyfile)
-    s.sendall(b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n")
-
-
 @contextlib.contextmanager
-def mock_server(certdata, keydata, host="localhost", port=0, callback=raw_callback):
+def mock_server(certdata, keydata, host="localhost", port=0, callback=handshake_callback):
     def serve(connection, certdata, keydata, host, port, callback):
         sock = socket.socket()
         try:
@@ -90,7 +85,7 @@ def mock_server(certdata, keydata, host="localhost", port=0, callback=raw_callba
 
 
 @testenv
-def local(ok_expected, cn, callback=https_callback):
+def local(ok_expected, cn, callback=handshake_callback):
     certdata, keydata, cadata = gencert(cn)
 
     with mock_server(certdata, keydata, callback=callback) as (host, port):

--- a/showrunner/testenv.py
+++ b/showrunner/testenv.py
@@ -1,4 +1,9 @@
+import ssl
+import socket
 import contextlib
+import multiprocessing
+from .utils import tmpfiles
+from .gencert import gencert
 
 
 class _TestEnv(object):
@@ -9,6 +14,9 @@ class _TestEnv(object):
 
     def __repr__(self):
         """
+        Return a readable representation of the wrapped function and its
+        call arguments.
+
         >>> def mytest(a, b):
         ...     pass
         >>> repr(_TestEnv(mytest, [1], {"b": 2}))
@@ -35,3 +43,56 @@ def testenv(func):
 @testenv
 def badssl(ok_expected, name):
     yield ok_expected, name + ".badssl.com", 443, None
+
+
+def raw_callback(conn, certfile, keyfile):
+    ssl.wrap_socket(conn, server_side=True, certfile=certfile, keyfile=keyfile)
+
+
+def https_callback(conn, certfile, keyfile):
+    s = ssl.wrap_socket(conn, server_side=True, certfile=certfile, keyfile=keyfile)
+    s.sendall(b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n")
+
+
+@contextlib.contextmanager
+def mock_server(certdata, keydata, host="localhost", port=0, callback=raw_callback):
+    def serve(connection, certdata, keydata, host, port, callback):
+        sock = socket.socket()
+        try:
+            sock.bind((host, port))
+            sock.listen(1)
+
+            _, port = sock.getsockname()
+            connection.send((host, port))
+
+            conn, addr = sock.accept()
+        finally:
+            sock.close()
+
+        try:
+            with tmpfiles(certdata, keydata) as (certfile, keyfile):
+                callback(conn, certfile, keyfile)
+        finally:
+            conn.close()
+
+    reader, writer = multiprocessing.Pipe(duplex=False)
+    process = multiprocessing.Process(
+        target=serve,
+        args=[writer, certdata, keydata, host, port, callback]
+    )
+    process.start()
+    try:
+        host, port = reader.recv()
+        yield host, port
+    finally:
+        process.terminate()
+        process.join()
+
+
+@testenv
+def local(ok_expected, cn, callback=https_callback):
+    certdata, keydata, cadata = gencert(cn)
+
+    with mock_server(certdata, keydata, callback=callback) as (host, port):
+        with tmpfiles(cadata) as cafile:
+            yield ok_expected, host, port, cafile

--- a/showrunner/utils.py
+++ b/showrunner/utils.py
@@ -1,0 +1,40 @@
+import os
+import shutil
+import tempfile
+import functools
+import contextlib
+
+
+def memoized(func):
+    value = []
+
+    @functools.wraps(func)
+    def _memoized():
+        if not value:
+            value.append(func())
+        return value[0]
+
+    return _memoized
+
+
+@contextlib.contextmanager
+def tmpfiles(first, *rest):
+    datas = [first] + list(rest)
+
+    tmp = tempfile.mkdtemp()
+    try:
+        filenames = []
+
+        for index, data in enumerate(datas):
+            filename = os.path.join(tmp, str(index))
+            with open(filename, "wb") as fileobj:
+                fileobj.write(data)
+                fileobj.flush()
+            filenames.append(filename)
+
+        if not rest:
+            yield filenames[0]
+        else:
+            yield filenames
+    finally:
+        shutil.rmtree(tmp)


### PR DESCRIPTION
This pull request continues from pull request #4, adding some major features to showrunner. The set of commits also contains some smaller fixes to Python 2.7 compatibility and `examples/python3-urllib/run.py`.
## On-the-fly Certificate Generation

Add `showrunner.gencert.gencert(cn="...")` for generating a PEM encoded server certificate + private key pair and a PEM ca bundle against which the server certificate verifies. The function basically just wraps the `openssl` command and generates a server certificate for the given Common Name. To save time the private server key and the private CA key are generated once per process.

As an example you can generate `cert.pem`, `cert.key` and `ca.pem` like this:

``` python
from showrunner.gencert import gencert


def writefile(filename, data):
    with open(filename, "wb") as f:
        f.write(data)


cert, key, ca = gencert("localhost")
writefile("cert.pem", cert)
writefile("cert.key", key)
writefile("ca.pem", ca)
```

Now launching a HTTP server on localhost with the `cert.pem` and `cert.key` files allows clients to create a verified connection to it using the `ca.pem` CA file.
## Helpers for Local Testing

Add helpers for writing local test servers: `showrunner.testenv.local(ok_expected, cn, [callback=...])` launches a simple temporary TLS server on `localhost` (with keys generated by `gencert`).  After the test has been completed the temporary TLS server gets shut down.
- `ok_expected` tells whether the connected clients should be able to verify the server certificate.
- `cn` tells the Common Name that should be passed to `gencert` when generating the server certificates.
- The optional `callback` argument can be passed in to modify how a created connection socket is used after a socket connection has been established. The default callback just does the TLS handshake, but is also used by the HTTPS bundle (described later) to imitate a webserver. For an example see [`showrunner.bundles.https.https_callback`](https://github.com/ouspg/trytls/blob/showrunner/showrunner/bundles/https.py#L6-L8).
## Test Bundles

Add the concept of _test bundles_ and add a command line option `-t`/`--test-bundle` to the `trytls` tool for configuring the used test bundle.

A test bundle is a bundle of tests specialized for some protocol/situation ("just a plain TLS handshake", "a HTTPS server", ...). In practice a test bundle is just a named list of tests to be run. As an example see [`showrunner.bundles.handshakes.all_tests`](https://github.com/ouspg/trytls/blob/showrunner/showrunner/bundles/handshake.py#L16) (described later).

The command line parameter `-t` (or `--test-bundle`) is used to tell which test suite should be run. The value should be an absolute Python import path, for example `showrunner.bundles.https.all_tests` for importing the test list `all_tests` from the `showrunner.bundles.https` module. For convenience the path can also be a relative one (i.e. starting with `.`) in which case the bundle is imported under the `showrunner.bundles` package meant for built-in bundles. Therefore `showrunner.bundles.handshake.all_tests` can be referred to as `.handshake.all_tests`.

The default `--test-bundle` value is `.handshake.all_tests`.

The support for absolute import paths is there because that allows people to write their own test bundles that don't have to be a part of the `showrunner` package. This in turn makes it easier to host the bundle code somewhere else than this repository.
### Built-in Bundles

Add some example test bundles of varying quality:
- `.handshake.all_tests`/`showrunner.bundles.handshake.all_tests` for testing plain TLS handshakes (on a local server and on the BadSSL servers). This is the default test bundle for the `trytls` tool.
- `.https.all_tests`/`showrunner.bundles.https.all_tests` that is pretty much like the `.handshake` bundle but also sends a rudimentary HTTP response back to the client. Should help in testing HTTP clients.
- `.imap.all_tests`/`showrunner.bundles.imap.all_tests` that currently just tells to connect to Gmail's IMAP servers.
### Example

Testing the `examples/python3-urllib/run.py` stub against only the local tests in the builtin HTTPS bundle:

``` console
$ trytls -t .https.local_tests python3 examples/python3-urllib/run.py
```
