### PR TITLE
Add go http client stub

### DIFF
--- a/tryTLS/stubs/go-nethttp.go
+++ b/tryTLS/stubs/go-nethttp.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+func usage() {
+	fmt.Printf("Usage: %v <URL>", os.Args[0])
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		usage()
+		return
+	}
+	url := os.Args[1]
+
+	// Perform a HTTP Request
+	_, err := http.Get(url)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
```
[joneskoo@grant trytls]$ go run tryTLS/stubs/go-nethttp.go https://expired.badssl.com/
Get https://expired.badssl.com/: x509: certificate has expired or is not yet valid
exit status 1
[joneskoo@grant trytls]$ go run tryTLS/stubs/go-nethttp.go https://self-signed.badssl.com/      
Get https://self-signed.badssl.com/: x509: certificate signed by unknown authority
exit status 1
[joneskoo@grant trytls]$ go run tryTLS/stubs/go-nethttp.go https://wrong.host.badssl.com/      
Get https://wrong.host.badssl.com/: x509: certificate is valid for *.badssl.com, badssl.com, not wrong.host.badssl.com
exit status 1
[joneskoo@grant trytls]$ go run tryTLS/stubs/go-nethttp.go https://badssl.com/           
[joneskoo@grant trytls]$ echo $?
0

```
