### PR TITLE
Update the trytls tool and examples to support the new return value "spec"

### DIFF
--- a/showrunner/runner.py
+++ b/showrunner/runner.py
@@ -37,7 +37,8 @@ def run_one(args, host, port, cafile=None):
     process = subprocess.Popen(
         args,
         stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
     )
     stdout, stderr = process.communicate()
 
@@ -68,7 +69,7 @@ def run(args, tests):
                 print("ERROR process exited with return code {}".format(pf.args[0]))
                 stderr = pf.args[1]
                 if stderr:
-                    print(indent(stderr, " " * 4).decode("ascii", "replace"))
+                    print(indent(stderr, " " * 4).rstrip().decode("ascii", "replace"))
             else:
                 if bool(ok) == bool(ok_expected):
                     print("PASS", test)

--- a/stubs/haskell-HaskellNet/src/Main.hs
+++ b/stubs/haskell-HaskellNet/src/Main.hs
@@ -28,9 +28,9 @@ main = do
   c <- catch (connectIMAPSSLWithSettings host settings)
              (\exception -> do
                  let _ = exception :: SomeException
-                 putStrLn "FAIL"
+                 putStrLn "VERIFY FAILURE"
                  exitSuccess
              )
 
-  putStrLn "OK"
+  putStrLn "VERIFY SUCCESS"
   exitSuccess

--- a/stubs/haskell-wreq/src/Main.hs
+++ b/stubs/haskell-wreq/src/Main.hs
@@ -24,9 +24,9 @@ main = do
   r <- catch (get $ "https://" ++ host ++ ":" ++ port)
              (\exception -> do
                  let _ = exception :: SomeException
-                 putStrLn "FAIL"
+                 putStrLn "VERIFY FAILURE"
                  exitSuccess
              )
 
-  putStrLn "OK"
+  putStrLn "VERIFY SUCCESS"
   exitSuccess

--- a/stubs/python3-imaplib/run.py
+++ b/stubs/python3-imaplib/run.py
@@ -14,6 +14,6 @@ else:
 try:
     imaplib.IMAP4_SSL(host, port, ssl_context=ssl_context)
 except (ssl.SSLError, ssl.CertificateError):
-    print("FAIL")
+    print("VERIFY FAILURE")
 else:
-    print("OK")
+    print("VERIFY SUCCESS")

--- a/stubs/python3-urllib/run.py
+++ b/stubs/python3-urllib/run.py
@@ -10,10 +10,10 @@ cafile = sys.argv[3] if len(sys.argv) > 3 else None
 try:
     urllib.request.urlopen("https://" + host + ":" + port, cafile=cafile)
 except ssl.CertificateError:
-    print("FAIL")
+    print("VERIFY FAILURE")
 except urllib.error.URLError as exc:
     if not isinstance(exc.reason, ssl.SSLError):
         raise
-    print("FAIL")
+    print("VERIFY FAILURE")
 else:
-    print("OK")
+    print("VERIFY SUCCESS")


### PR DESCRIPTION
This pull request modifies the `trytls` tool and the example stubs that use the old calling convention (returning `OK` or `FAIL`) to the new calling convention (returning `VERIFY SUCCESS`, `VERIFY FAILURE` and `UNSUPPORTED`).

Also modify the ERROR message formatting: The stderr output is now rendered indented under the error line.

Closes #13.
