### PR TITLE
Haskell stubs: Fix to support latest spec

### DIFF
--- a/stubs/haskell-HaskellNet/src/Main.hs
+++ b/stubs/haskell-HaskellNet/src/Main.hs
@@ -19,6 +19,10 @@ main = do
     putStrLn $ prog ++ " <host> <port> [ca-bundle]"
     exitFailure
 
+  when (argc == 3) $ do
+    putStrLn "UNSUPPORTED"
+    exitSuccess
+
   let host = args !! 0
       port = args !! 1
       settings = defaultSettingsIMAPSSL {
@@ -28,9 +32,9 @@ main = do
   c <- catch (connectIMAPSSLWithSettings host settings)
              (\exception -> do
                  let _ = exception :: SomeException
-                 putStrLn "FAIL"
+                 putStrLn "VERIFY FAILURE"
                  exitSuccess
              )
 
-  putStrLn "OK"
+  putStrLn "VERIFY SUCCESS"
   exitSuccess

--- a/stubs/haskell-wreq/src/Main.hs
+++ b/stubs/haskell-wreq/src/Main.hs
@@ -18,12 +18,12 @@ main = do
     putStrLn $ prog ++ " <host> <port> [ca-bundle]"
     exitFailure
 
-  let host = args !! 0
-      port = args !! 1
-
   when (argc == 3) $ do
     putStrLn "UNSUPPORTED"
     exitSuccess
+
+  let host = args !! 0
+      port = args !! 1
 
   r <- catch (get $ "https://" ++ host ++ ":" ++ port)
              (\exception -> do

--- a/stubs/haskell-wreq/src/Main.hs
+++ b/stubs/haskell-wreq/src/Main.hs
@@ -21,6 +21,10 @@ main = do
   let host = args !! 0
       port = args !! 1
 
+  when (argc == 3) $ do
+    putStrLn "UNSUPPORTED"
+    exitSuccess
+
   r <- catch (get $ "https://" ++ host ++ ":" ++ port)
              (\exception -> do
                  let _ = exception :: SomeException

--- a/stubs/haskell-wreq/src/Main.hs
+++ b/stubs/haskell-wreq/src/Main.hs
@@ -28,9 +28,9 @@ main = do
   r <- catch (get $ "https://" ++ host ++ ":" ++ port)
              (\exception -> do
                  let _ = exception :: SomeException
-                 putStrLn "FAIL"
+                 putStrLn "VERIFY FAILURE"
                  exitSuccess
              )
 
-  putStrLn "OK"
+  putStrLn "VERIFY SUCCESS"
   exitSuccess


### PR DESCRIPTION
Now it properly gives "UNSUPPORTED" as well as "VERIFY OK" and "VERIFY FAILURE" return values.

```
$ trytls -- docker run --rm test-haskellnet 
PASS badssl(True, 'sha1-2016')
PASS badssl(False, 'expired')
SKIP local(True, 'localhost')
SKIP local(False, 'nothing')
```

```
$ trytls -- docker run --rm test-wreq 
PASS badssl(True, 'sha1-2016')
PASS badssl(False, 'expired')
SKIP local(True, 'localhost')
SKIP local(False, 'nothing')
```
