### PR TITLE
Require Python>=2.7.9/3.4.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,20 @@
+import sys
 from setuptools import setup, find_packages
+
+
+def format_version(version_info):
+    return ".".join(str(x) for x in version_info[:3])
+
+if sys.version_info < (3,):
+    py_required = (2, 7, 9)
+else:
+    py_required = (3, 4, 0)
+
+if sys.version_info < py_required:
+    sys.exit("ERROR: Python {0} or later required (you have {1})".format(
+        format_version(py_required),
+        format_version(sys.version_info)
+    ))
 
 setup(
     name="trytls",


### PR DESCRIPTION
This pull request adds a check to the beginning is `setup.py` that exits when the current Python version is not >=2.7.9/3.4.0.

Closes #29.
