### PR TITLE
Add two more build tool docs to README.md

### DIFF
--- a/stubs/haskell-HaskellNet/.gitignore
+++ b/stubs/haskell-HaskellNet/.gitignore
@@ -1,0 +1,4 @@
+.cabal-sandbox/
+.stack-work/
+cabal.sandbox.config
+TAGS

--- a/stubs/haskell-HaskellNet/README.md
+++ b/stubs/haskell-HaskellNet/README.md
@@ -2,7 +2,16 @@
 
 https://hackage.haskell.org/package/HaskellNet-SSL
 
-## Howto
+## Howto build and run
+
+You have three different options for running tests. Docker, Stack and
+Cabal.
+
+### Docker
+
+Tests can be easily run inside [Docker](https://www.docker.com/)
+container. This takes care of setting up the appropriate Haskell
+environment with all dependencies and test stub installed.
 
 build:
 
@@ -10,8 +19,86 @@ build:
 $ docker build -t test-haskellnet --rm .
 ```
 
+test:
+
+```
+$ docker run --rm test-haskellnet
+test-HaskellNet <host> <port> [ca-bundle]
+```
+
 run:
 
 ```
-docker run -ti --rm test-haskellnet
+$ trytls -- docker run --rm test-haskellnet
+```
+
+cleanup (destroys docker container image):
+
+```
+$ docker rmi test-haskellnet
+```
+
+### Stack
+
+If you have [The Haskell Tool Stack](http://www.haskellstack.org/)
+already installed then this might be easier and faster than Docker
+version above. However, `stack` might not use latest and greatest
+version of all required packages so check out the `resolver` setting
+from `stack.yaml` file and adjust to your needs or pass `--resolver`
+flag to `stack` command to select it at runtime.
+
+build:
+
+```
+$ stack build
+```
+
+test:
+
+```
+$ stack exec test-haskellnet
+test-haskellnet <host> <port> [ca-bundle]
+```
+
+run:
+
+```
+$ trytls -- stack exec test-Haskellnet
+```
+
+cleanup:
+
+```
+$ rm -rf .stack-work
+```
+
+### Cabal sandbox
+
+Cabal
+
+build:
+
+```
+$ cabal sandbox init
+$ cabal install --only-dependencies
+$ cabal build
+```
+
+test:
+
+```
+$ ./dist/build/test-HaskellNet/test-HaskellNet
+test-HaskellNet <host> <port> [ca-bundle]
+```
+
+run:
+
+```
+$ trytls ./dist/build/test-HaskellNet/test-HaskellNet
+```
+
+cleanup:
+
+```
+$ cabal sandbox delete
 ```


### PR DESCRIPTION
Now it's documented how to build and run this stub with Stack or Cabal(-install) which are the de facto tools in Haskell.

While there, add `.gitignore` for paths produced by different build tools.
