### PR TITLE
Updated the Copyright note in the LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Oulu University Secure Programming Group
+Copyright (c) 2016 by the TryTLS contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Based on the quick feedback trying to clarify Copyright so that
it doesn't imply assigning the copyrights if you contribute.

Currently policy is that you indicate or imply to distribute your
contribution under tha project license or attach the license of
your choice to your contribution. if your license is compatible
with the main license the this project can be distributed and
used whole.

Further Copyright transfer & assignment is unnecessary and this
I propose that misleading Copyright notice to be corrected. I
recommend alwayd distributing the project in a form that either
includes backreference to the project repository or at least
identifies the list of individual contributors so that
original Copyrights can be backtracked if necessary and
parental right gets respected.
