### PR TITLE
Add SSL Labs tests

### DIFF
--- a/runners/trytls/bundles/https.py
+++ b/runners/trytls/bundles/https.py
@@ -1,6 +1,6 @@
 import ssl
 import functools
-from ..testenv import badssl, badssl_onlymyca, local as _local
+from ..testenv import constant, badssl, badssl_onlymyca, local as _local
 
 
 def https_callback(conn, certfile, keyfile):
@@ -25,12 +25,22 @@ badssl_tests = [
 ]
 
 
+ssllabs_tests = [
+    constant(False, "www.ssllabs.com", 10443),
+    constant(False, "www.ssllabs.com", 10444),
+    constant(False, "www.ssllabs.com", 10445)
+]
+
+
 local_tests = [
     local(True, "localhost"),
     local(False, "nothing")
 ]
 
+
 badssl_only_my_ca = [
     badssl_onlymyca(False, "sha256")
 ]
-all_tests = badssl_tests + badssl_only_my_ca + local_tests
+
+
+all_tests = badssl_tests + badssl_only_my_ca + ssllabs_tests + local_tests

--- a/runners/trytls/testenv.py
+++ b/runners/trytls/testenv.py
@@ -41,8 +41,12 @@ def testenv(func):
 
 
 @testenv
+def constant(ok_expected, host, port, cafile=None):
+    yield ok_expected, host, port, cafile
+
+
 def badssl(ok_expected, name):
-    yield ok_expected, name + ".badssl.com", 443, None
+    return constant(ok_expected, name + ".badssl.com", 443)
 
 
 def handshake_callback(conn, certfile, keyfile):


### PR DESCRIPTION
This pull request adds SSL Labs tests www.ssllabs.com:10443, www.ssllabs.com:10444 and www.ssllabs.com:10445 to the `trytls` tool's HTTPS bundle.

Closes #31.
