### PR TITLE
[WIP] trytls tool fixes & enhancements

### DIFF
--- a/runners/trytls/__init__.py
+++ b/runners/trytls/__init__.py
@@ -1,5 +1,5 @@
 from .testenv import testenv
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"
 
 __all__ = ["testenv"]

--- a/runners/trytls/__init__.py
+++ b/runners/trytls/__init__.py
@@ -1,3 +1,5 @@
 from .testenv import testenv
 
+__version__ = "0.0.6"
+
 __all__ = ["testenv"]

--- a/runners/trytls/bundles/https.py
+++ b/runners/trytls/bundles/https.py
@@ -1,14 +1,85 @@
 import ssl
-import functools
-from ..testenv import constant, badssl, badssl_onlymyca, local as _local
+import sys
+import socket
+import contextlib
+import multiprocessing
+from ..utils import tmpfiles
+from ..gencert import gencert
+from ..testenv import testenv, constant
+
+try:
+    from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+except ImportError:
+    from http.server import HTTPServer, BaseHTTPRequestHandler
 
 
-def https_callback(conn, certfile, keyfile):
-    s = ssl.wrap_socket(conn, server_side=True, certfile=certfile, keyfile=keyfile)
-    s.sendall(b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n")
+def badssl(ok_expected, name):
+    return constant(ok_expected, name + ".badssl.com", 443)
 
 
-local = functools.partial(_local, callback=https_callback)
+@testenv
+def badssl_onlymyca(ok_expected, name):
+    _, _, cadata = gencert("localhost")
+    with tmpfiles(cadata) as cafile:
+        yield ok_expected, name + ".badssl.com", 443, cafile
+
+
+@contextlib.contextmanager
+def http_server(certdata, keydata, host="localhost", port=0):
+    class Server(HTTPServer):
+        ALLOWED_EXCEPTIONS = (socket.error,)
+
+        def handle_error(self, request, client_address):
+            exc_type, _, _ = sys.exc_info()
+            if isinstance(exc_type, type) and issubclass(exc_type, self.ALLOWED_EXCEPTIONS):
+                return
+            HTTPServer.handle_error(self, request, client_address)
+
+    class Handler(BaseHTTPRequestHandler):
+        def setup(self):
+            with tmpfiles(certdata, keydata) as (certfile, keyfile):
+                self.request = ssl.wrap_socket(
+                    self.request,
+                    server_side=True,
+                    certfile=certfile,
+                    keyfile=keyfile
+                )
+            return BaseHTTPRequestHandler.setup(self)
+
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "0")
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            pass
+
+    def serve(connection, certdata, keydata, host, port):
+        server = Server((host, port), Handler)
+        connection.send((host, server.server_port))
+        server.handle_request()
+
+    reader, writer = multiprocessing.Pipe(duplex=False)
+    process = multiprocessing.Process(
+        target=serve,
+        args=[writer, certdata, keydata, host, port]
+    )
+    process.start()
+    try:
+        host, port = reader.recv()
+        yield host, port
+    finally:
+        process.terminate()
+        process.join()
+
+
+@testenv
+def local(ok_expected, cn):
+    certdata, keydata, cadata = gencert(cn)
+
+    with http_server(certdata, keydata) as (host, port):
+        with tmpfiles(cadata) as cafile:
+            yield ok_expected, host, port, cafile
 
 
 badssl_tests = [

--- a/runners/trytls/bundles/https.py
+++ b/runners/trytls/bundles/https.py
@@ -5,7 +5,7 @@ import contextlib
 import multiprocessing
 from ..utils import tmpfiles
 from ..gencert import gencert
-from ..testenv import testenv, constant
+from ..testenv import testenv
 
 try:
     from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
@@ -13,8 +13,9 @@ except ImportError:
     from http.server import HTTPServer, BaseHTTPRequestHandler
 
 
+@testenv
 def badssl(ok_expected, name):
-    return constant(ok_expected, name + ".badssl.com", 443)
+    yield ok_expected, name + ".badssl.com", 443, None
 
 
 @testenv
@@ -22,6 +23,11 @@ def badssl_onlymyca(ok_expected, name):
     _, _, cadata = gencert("localhost")
     with tmpfiles(cadata) as cafile:
         yield ok_expected, name + ".badssl.com", 443, cafile
+
+
+@testenv
+def ssllabs(ok_expected, port, host="www.ssllabs.com"):
+    yield ok_expected, host, port, None
 
 
 @contextlib.contextmanager
@@ -97,9 +103,9 @@ badssl_tests = [
 
 
 ssllabs_tests = [
-    constant(False, "www.ssllabs.com", 10443),
-    constant(False, "www.ssllabs.com", 10444),
-    constant(False, "www.ssllabs.com", 10445)
+    ssllabs(False, port=10443),
+    ssllabs(False, port=10444),
+    ssllabs(False, port=10445)
 ]
 
 

--- a/runners/trytls/gencert.py
+++ b/runners/trytls/gencert.py
@@ -36,6 +36,11 @@ def _cert_key():
     return openssl(["genrsa", "4096"])
 
 
+_EXT_FILE_DATA = b"""
+basicConstraints = CA:FALSE
+"""
+
+
 def gencert(cn):
     subj = "/CN=" + cn
     ca_key = _ca_key()
@@ -50,9 +55,9 @@ def gencert(cn):
         cert_csr = openssl(["req", "-new", "-subj", subj, "-key", cert_keyfile])
 
     # Sign the certificate with the CA
-    with tmpfiles(ca_key, ca_data) as (ca_keyfile, ca_file):
+    with tmpfiles(ca_key, ca_data, _EXT_FILE_DATA) as (ca_keyfile, ca_file, ext_file):
         cert_data = openssl(
-            ["x509", "-req", "-CA", ca_file, "-CAkey", ca_keyfile, "-set_serial", "01"],
+            ["x509", "-req", "-extfile", ext_file, "-CA", ca_file, "-CAkey", ca_keyfile, "-set_serial", "01"],
             input=cert_csr
         )
 

--- a/runners/trytls/gencert.py
+++ b/runners/trytls/gencert.py
@@ -60,5 +60,5 @@ def gencert(cn):
 
 
 def openssl_version():
-    ver = openssl(["version", "-v"]).strip()
-    return " ".join(ver.split(None, 2)[:2])
+    ver = openssl(["version", "-v"]).strip().decode("ascii", "replace")
+    return " ".join(ver.split()[:2])

--- a/runners/trytls/runner.py
+++ b/runners/trytls/runner.py
@@ -1,22 +1,12 @@
 from __future__ import print_function, unicode_literals
 
 import sys
-import gencert
-import platform
 import argparse
 import subprocess
 import pkg_resources
 from colorama import Fore, Back, Style, init, AnsiToWin32
 
-try:
-    from shlex import quote as shlex_quote
-except ImportError:
-    def shlex_quote(string):
-        if string.isalnum():
-            return string
-        return "'" + string.replace("'", "\\'") + "'"
-
-from . import __version__
+from . import __version__, gencert, utils
 
 
 # Initialize colorama without wrapping sys.stdout globally
@@ -53,45 +43,21 @@ def indent(text, by=4):
     return "".join(spaces + line for line in lines)
 
 
-def python_info():
-    return platform.python_implementation() + " " + platform.python_version()
-
-
-def platform_info():
-    if sys.platform == "linux2":
-        distname, version, _ = platform.linux_distribution()
-        if not distname:
-            return "Linux"
-        if not version:
-            return "Linux ({})".format(distname)
-        return "Linux ({} {})".format(distname, version)
-    elif sys.platform == "darwin":
-        version, _, _ = platform.mac_ver()
-        if version.startswith("10."):
-            return "OS X {}".format(version)
-        return "Darwin"
-    return platform.system()
-
-
-def format_command(args):
-    return " ".join(map(shlex_quote, args))
-
-
 def output_info(args, openssl_version, runner_name="trytls"):
     output(
         "{Style.BRIGHT}platform:{RESET} {platform}",
-        platform=platform_info()
+        platform=utils.platform_info()
     )
     output(
         "{Style.BRIGHT}runner:{RESET} {runner} {version} ({python}, {openssl})",
         runner=runner_name,
         version=__version__,
-        python=python_info(),
+        python=utils.python_info(),
         openssl=openssl_version
     )
     output(
         "{Style.BRIGHT}stub:{RESET} {command}",
-        command=format_command(args)
+        command=utils.format_command(args)
     )
 
 

--- a/runners/trytls/testenv.py
+++ b/runners/trytls/testenv.py
@@ -33,8 +33,3 @@ def testenv(func):
     def _testenv(*args, **keys):
         return _TestEnv(func, args, keys)
     return _testenv
-
-
-@testenv
-def constant(ok_expected, host, port, cafile=None):
-    yield ok_expected, host, port, cafile

--- a/runners/trytls/testenv.py
+++ b/runners/trytls/testenv.py
@@ -1,9 +1,4 @@
-import ssl
-import socket
 import contextlib
-import multiprocessing
-from .utils import tmpfiles
-from .gencert import gencert
 
 
 class _TestEnv(object):
@@ -43,62 +38,3 @@ def testenv(func):
 @testenv
 def constant(ok_expected, host, port, cafile=None):
     yield ok_expected, host, port, cafile
-
-
-def badssl(ok_expected, name):
-    return constant(ok_expected, name + ".badssl.com", 443)
-
-
-def handshake_callback(conn, certfile, keyfile):
-    ssl.wrap_socket(conn, server_side=True, certfile=certfile, keyfile=keyfile)
-
-
-@contextlib.contextmanager
-def mock_server(certdata, keydata, host="localhost", port=0, callback=handshake_callback):
-    def serve(connection, certdata, keydata, host, port, callback):
-        sock = socket.socket()
-        try:
-            sock.bind((host, port))
-            sock.listen(1)
-
-            _, port = sock.getsockname()
-            connection.send((host, port))
-
-            conn, addr = sock.accept()
-        finally:
-            sock.close()
-
-        try:
-            with tmpfiles(certdata, keydata) as (certfile, keyfile):
-                callback(conn, certfile, keyfile)
-        finally:
-            conn.close()
-
-    reader, writer = multiprocessing.Pipe(duplex=False)
-    process = multiprocessing.Process(
-        target=serve,
-        args=[writer, certdata, keydata, host, port, callback]
-    )
-    process.start()
-    try:
-        host, port = reader.recv()
-        yield host, port
-    finally:
-        process.terminate()
-        process.join()
-
-
-@testenv
-def local(ok_expected, cn, callback=handshake_callback):
-    certdata, keydata, cadata = gencert(cn)
-
-    with mock_server(certdata, keydata, callback=callback) as (host, port):
-        with tmpfiles(cadata) as cafile:
-            yield ok_expected, host, port, cafile
-
-
-@testenv
-def badssl_onlymyca(ok_expected, name):
-    _, _, cadata = gencert("localhost")
-    with tmpfiles(cadata) as cafile:
-        yield ok_expected, name + ".badssl.com", 443, cafile

--- a/runners/trytls/utils.py
+++ b/runners/trytls/utils.py
@@ -1,8 +1,42 @@
 import os
+import sys
 import shutil
+import platform
 import tempfile
 import functools
 import contextlib
+
+try:
+    from shlex import quote as _shlex_quote
+except ImportError:
+    def _shlex_quote(string):
+        if string.isalnum():
+            return string
+        return "'" + string.replace("'", "\\'") + "'"
+
+
+def format_command(args):
+    return " ".join(_shlex_quote(arg) for arg in args)
+
+
+def python_info():
+    return platform.python_implementation() + " " + platform.python_version()
+
+
+def platform_info():
+    if sys.platform == "linux2":
+        distname, version, _ = platform.linux_distribution()
+        if not distname:
+            return "Linux"
+        if not version:
+            return "Linux ({})".format(distname)
+        return "Linux ({} {})".format(distname, version)
+    elif sys.platform == "darwin":
+        version, _, _ = platform.mac_ver()
+        if version.startswith("10."):
+            return "OS X {}".format(version)
+        return "Darwin"
+    return platform.system()
 
 
 def memoized(func):

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,30 @@
+import os
+import imp
 import sys
 from setuptools import setup, find_packages
 
-
-def format_version(version_info):
-    return ".".join(str(x) for x in version_info[:3])
-
+# Check the the Python version
 if sys.version_info < (3,):
     py_required = (2, 7, 9)
 else:
     py_required = (3, 4, 0)
 
 if sys.version_info < py_required:
+    def format_version(version_info):
+        return ".".join(str(x) for x in version_info[:3])
+
     sys.exit("ERROR: Python {0} or later required (you have {1})".format(
         format_version(py_required),
         format_version(sys.version_info)
     ))
 
+# Import the local version of the package
+found = imp.find_module("trytls", [os.path.join(os.path.dirname(__file__), "runners")])
+trytls = imp.load_module("trytls", *found)
+
 setup(
     name="trytls",
-    version="0.0.6",
+    version=trytls.__version__,
     package_dir={"": "./runners"},
     packages=find_packages("./runners"),
     entry_points={


### PR DESCRIPTION
This pull request implements various `trytls` tool fixes and usability enhancements:
- Print platform, runner version and stub command at the beginning of each run. Closes #50.
  
  ``` sh
  $ trytls https python stubs/python-urllib2/run.py
  platform: Linux (Ubuntu 16.04)
  runner: trytls 0.0.7 (CPython 2.7.11+, OpenSSL 1.0.2g-fips)
  stub: python 'stubs/python-urllib2/run.py'
    PASS constant(False, 'expired.badssl.com', 443)
    PASS constant(False, 'wrong.host.badssl.com', 443)
    PASS constant(False, 'self-signed.badssl.com', 443)
    ...
  ```
- Show an error if OpenSSL can't be found from the search path. Exit with code 1 when this happens. Closes #32.
  
  ``` sh
  $ trytls https python
  ERROR: openssl command not found in the search path
  $ echo $?
  1
  ```
- Use Python standard library's `BaseHTTPServer`/`http.server` for the mock HTTP server. Also generate V3 certs. Fixes #65.

This PR also bump the `trytls` tool version to 0.0.7.
