### PR TITLE
Python-requests stub

### DIFF
--- a/stubs/python-requests/README.md
+++ b/stubs/python-requests/README.md
@@ -4,9 +4,9 @@ This stub has been tested with:
  * Python 2.7.12
  * [requests-library](http://docs.python-requests.org/en/master/) v.2.10
 
- # Examples
+# Examples
 
- ```
+```sh
 $ python stubs/python-requests/run.py sha256.badssl.com 443
 VERIFY SUCCESS
 
@@ -15,7 +15,6 @@ VERIFY FAILURE
 
 $ python stubs/python-requests/run.py sha256.badssl.com 443 <path>/pki/certs/theonlycertitrust.crt
 VERIFY FAILURE
-
 ```
 
 # Credits

--- a/stubs/python-requests/README.md
+++ b/stubs/python-requests/README.md
@@ -1,0 +1,23 @@
+# Requirements
+
+This stub has been tested with:
+ * Python 2.7.12
+ * [requests-library](http://docs.python-requests.org/en/master/) v.2.10
+
+ # Examples
+
+ ```
+$ python stubs/python-requests/run.py sha256.badssl.com 443
+VERIFY SUCCESS
+
+python stubs/python-requests/run.py expired.badssl.com 443
+VERIFY FAILURE
+
+$ python stubs/python-requests/run.py sha256.badssl.com 443 <path>/pki/certs/theonlycertitrust.crt
+VERIFY FAILURE
+
+```
+
+# Credits
+
+Based on python3-urllib -stub.

--- a/stubs/python-requests/run.py
+++ b/stubs/python-requests/run.py
@@ -1,15 +1,13 @@
 import sys
 import requests
 
-
 host = sys.argv[1]
 port = sys.argv[2]
-cafile = sys.argv[3] if len(sys.argv) > 3 else True
+verify = sys.argv[3] if len(sys.argv) > 3 else True
 
 try:
-    r = requests.get("https://" + host + ":" + port, verify=cafile)
+    r = requests.get("https://" + host + ":" + port, verify=verify)
 except requests.exceptions.SSLError as err:
-    #    print err
     print ("VERIFY FAILURE")
 else:
     print("VERIFY SUCCESS")

--- a/stubs/python-requests/run.py
+++ b/stubs/python-requests/run.py
@@ -1,0 +1,15 @@
+import sys
+import requests
+
+
+host = sys.argv[1]
+port = sys.argv[2]
+cafile = sys.argv[3] if len(sys.argv) > 3 else False
+
+try:
+    r = requests.get("https://" + host + ":" + port, cert=cafile)
+except requests.exceptions.SSLError as err:
+    #    print err
+    print ("VERIFY FAILURE")
+else:
+    print("VERIFY SUCCESS")

--- a/stubs/python-requests/run.py
+++ b/stubs/python-requests/run.py
@@ -4,10 +4,10 @@ import requests
 
 host = sys.argv[1]
 port = sys.argv[2]
-cafile = sys.argv[3] if len(sys.argv) > 3 else False
+cafile = sys.argv[3] if len(sys.argv) > 3 else True
 
 try:
-    r = requests.get("https://" + host + ":" + port, cert=cafile)
+    r = requests.get("https://" + host + ":" + port, verify=cafile)
 except requests.exceptions.SSLError as err:
     #    print err
     print ("VERIFY FAILURE")


### PR DESCRIPTION
This stub uses the python requests -library for TLS connection. 
- [x] Check why one localhost check fails
  - it failed because the ca cert was provided using wrong parameter.
