### PR TITLE
Remove rest of the IMAP references

### DIFF
--- a/runners/bashtls/shared/simplerunner/stubs/python3.stubs
+++ b/runners/bashtls/shared/simplerunner/stubs/python3.stubs
@@ -1,2 +1,1 @@
-python3-imaplib
 python3-urllib

--- a/runners/trytls/README.md
+++ b/runners/trytls/README.md
@@ -23,7 +23,6 @@ trytls: error: missing the bundle argument
 
 Valid bundle options:
   https
-  imap
 ```
 
 For example, when testing a HTTP(S) library you'd want to use the `https` bundle. That specific bundle knows to answer to the library's requests with proper HTTP responses, making testing easier.
@@ -47,7 +46,7 @@ The specific exit code in such situations is 3, to distinguish it from other com
 
 ## Bundles
 
-A test bundle is a collection of tests specialized for some protocol/situation ("an HTTPS server", "an IMAP server", ...). In practice a test bundle is just a named list of tests to be run. As an example see [`bundles/https.py`](./bundles/https.py).
+A test bundle is a collection of tests specialized for some protocol/situation ("an HTTPS server", ...). In practice a test bundle is just a named list of tests to be run. As an example see [`bundles/https.py`](./bundles/https.py).
 
 The bundles are registered as `setuptools` entrypoints.
 

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ setup(
             "trytls=trytls.runner:main"
         ],
         "trytls.bundles": [
-            "https=trytls.bundles.https:all_tests",
-            "imap=trytls.bundles.imap:all_tests"
+            "https=trytls.bundles.https:all_tests"
         ]
     },
     install_requires=[


### PR DESCRIPTION
This is contination for #79 where I forgot to remove some references to the IMAP stubs and bundles. Also `setup.py` is updated accordingly.
