### PR TITLE
Fix several non-crash issues

### DIFF
--- a/backends/badssl.md
+++ b/backends/badssl.md
@@ -1,8 +1,8 @@
-#BadSSL services and reasons for usage/ignore
+# BadSSL services and reasons for usage/ignore
 
-##Used
+## Used
 
-* `expired`: Obsolete cert should not be valid
+* `expired`: Expired cert should not be valid
 * `wrong.host`: Wrong host should not be valid
 * `self-signed`: Who knows who signed? Should not be valid
 * `sha256`: Should be valid to future proof
@@ -12,7 +12,7 @@
 * `edellroot`: Rotten roots CA should not be valid
 * `dsdtestprovider`: Unproviding CA should not be valid
 
-##Unused
+## Unused
 
 * `sha1-2016`: Maybe invalid after 2016
 * `sha1-2017`: Maybe invalid after 2017

--- a/runners/trytls/__init__.py
+++ b/runners/trytls/__init__.py
@@ -1,5 +1,5 @@
 from .testenv import testenv
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 __all__ = ["testenv"]

--- a/runners/trytls/bundles/https.py
+++ b/runners/trytls/bundles/https.py
@@ -94,7 +94,6 @@ badssl_tests = [
     badssl(False, "self-signed"),  # not just one's own claims
     badssl(True, "sha256"),  # future proof sha
     badssl(True, "1000-sans"),  # massive alternative names
-    badssl(True, "10000-sans"),  # massive alternative names
     badssl(False, "incomplete-chain"),  # should have full proof of chain to trusted CA
     badssl(False, "superfish"),  # super fishy CA
     badssl(False, "edellroot"),  # rotten roots CA

--- a/runners/trytls/bundles/https.py
+++ b/runners/trytls/bundles/https.py
@@ -5,7 +5,7 @@ import contextlib
 import multiprocessing
 from ..utils import tmpfiles
 from ..gencert import gencert
-from ..testenv import testenv
+from ..testenv import testenv, Test
 
 try:
     from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
@@ -14,20 +14,37 @@ except ImportError:
 
 
 @testenv
-def badssl(ok_expected, name):
-    yield ok_expected, name + ".badssl.com", 443, None
+def badssl(accept, name, description):
+    yield Test(
+        accept=accept,
+        description=description,
+        host=name + ".badssl.com",
+        port=443
+    )
 
 
 @testenv
-def badssl_onlymyca(ok_expected, name):
+def badssl_onlymyca(description):
     _, _, cadata = gencert("localhost")
+
     with tmpfiles(cadata) as cafile:
-        yield ok_expected, name + ".badssl.com", 443, cafile
+        yield Test(
+            accept=False,
+            description=description,
+            host="sha256.badssl.com",
+            port=443,
+            cafile=cafile
+        )
 
 
 @testenv
-def ssllabs(ok_expected, port, host="www.ssllabs.com"):
-    yield ok_expected, host, port, None
+def ssllabs(accept, port, description):
+    yield Test(
+        accept=accept,
+        description=description,
+        host="www.ssllabs.com",
+        port=port
+    )
 
 
 @contextlib.contextmanager
@@ -80,43 +97,45 @@ def http_server(certdata, keydata, host="localhost", port=0):
 
 
 @testenv
-def local(ok_expected, cn):
+def local(accept, cn, description):
     certdata, keydata, cadata = gencert(cn)
 
     with http_server(certdata, keydata) as (host, port):
         with tmpfiles(cadata) as cafile:
-            yield ok_expected, host, port, cafile
+            yield Test(
+                accept=accept,
+                description=description,
+                host=host,
+                port=port,
+                cafile=cafile
+            )
 
 
 badssl_tests = [
-    badssl(False, "expired"),  # not with an obsolete cert
-    badssl(False, "wrong.host"),  # not with a wrong name
-    badssl(False, "self-signed"),  # not just one's own claims
-    badssl(True, "sha256"),  # future proof sha
-    badssl(True, "1000-sans"),  # massive alternative names
-    badssl(False, "incomplete-chain"),  # should have full proof of chain to trusted CA
-    badssl(False, "superfish"),  # super fishy CA
-    badssl(False, "edellroot"),  # rotten roots CA
-    badssl(False, "dsdtestprovider")  # unproviding CA
+    badssl(False, "expired", "expired certificate"),
+    badssl(False, "wrong.host", "wrong hostname in certificate"),
+    badssl(False, "self-signed", "self-signed certificate"),
+    badssl(True, "sha256", "SHA-256 signature"),
+    badssl(True, "1000-sans", "1000 subjectAltNames"),
+    badssl(False, "incomplete-chain", "incomplete chain of trust"),
+    badssl(False, "superfish", "Superfish CA"),
+    badssl(False, "edellroot", "eDellRoot CA"),
+    badssl(False, "dsdtestprovider", "DSDTestProvider CA")
 ]
 
 
 ssllabs_tests = [
-    ssllabs(False, port=10443),
-    ssllabs(False, port=10444),
-    ssllabs(False, port=10445)
+    ssllabs(False, 10443, "protect against an OS X vulnerability"),
+    ssllabs(False, 10444, "protect against the FREAK attack"),
+    ssllabs(False, 10445, "protect against the Logjam attack")
 ]
 
 
 local_tests = [
-    local(True, "localhost"),
-    local(False, "nothing")
+    local(True, "localhost", "valid localhost certificate"),
+    local(False, "nothing", "invalid localhost certificate"),
+    badssl_onlymyca("use only the given CA bundle, not system's")
 ]
 
 
-badssl_only_my_ca = [
-    badssl_onlymyca(False, "sha256")
-]
-
-
-all_tests = badssl_tests + badssl_only_my_ca + ssllabs_tests + local_tests
+all_tests = badssl_tests + ssllabs_tests + local_tests

--- a/runners/trytls/gencert.py
+++ b/runners/trytls/gencert.py
@@ -48,7 +48,7 @@ def gencert(cn):
 
     # Generate the CA
     with tmpfiles(ca_key) as ca_keyfile:
-        ca_data = openssl(["req", "-new", "-key", ca_keyfile, "-x509", "-subj", "/"])
+        ca_data = openssl(["req", "-new", "-key", ca_keyfile, "-x509", "-subj", "/O=Fake Certificate Authority"])
 
     # Generate a certificate signing request
     with tmpfiles(cert_key) as cert_keyfile:

--- a/runners/trytls/result.py
+++ b/runners/trytls/result.py
@@ -1,0 +1,28 @@
+class _Result(object):
+    def __init__(self, reason="", details=""):
+        self.reason = reason
+        self.details = details
+
+    @property
+    def type(self):
+        return type(self)
+
+    @property
+    def name(self):
+        return type(self).__name__.upper()
+
+
+class Pass(_Result):
+    pass
+
+
+class Skip(_Result):
+    pass
+
+
+class Fail(_Result):
+    pass
+
+
+class Error(_Result):
+    pass

--- a/runners/trytls/testenv.py
+++ b/runners/trytls/testenv.py
@@ -1,29 +1,24 @@
 import contextlib
 
 
+class Test(object):
+    def __init__(self, accept, description, host, port, cafile=None, name=None):
+        self.accept = accept
+        self.description = description
+        self.host = host
+        self.port = port
+        self.cafile = cafile
+
+        if name is None:
+            name = "{}:{}".format(self.host, self.port)
+        self.name = name
+
+
 class _TestEnv(object):
     def __init__(self, func, args, kwargs):
         self._func = func
         self._args = args
         self._kwargs = kwargs
-
-    def __repr__(self):
-        """
-        Return a readable representation of the wrapped function and its
-        call arguments.
-
-        >>> def mytest(a, b):
-        ...     pass
-        >>> repr(_TestEnv(mytest, [1], {"b": 2}))
-        'mytest(1, b=2)'
-        """
-
-        params = []
-        if self._args:
-            params.extend("{v!r}".format(v=v) for v in self._args)
-        if self._kwargs:
-            params.extend("{k}={v!r}".format(k=k, v=v) for (k, v) in self._kwargs.items())
-        return "{name}({params})".format(name=self._func.__name__, params=", ".join(params))
 
     def __call__(self):
         return contextlib.contextmanager(self._func)(*self._args, **self._kwargs)


### PR DESCRIPTION
This pull request fixes several non-crash issues:
- Fix `trytls.gencert` to _not_ generate certificates an empty issuer. The empty issuer caused problems with [`http-kit`](http://www.http-kit.org/).
- Remove the 10000-sans BadSSL.com test.
- Restructure formatting, now tests should always have a short description.

Also bump version number to 0.0.8 (from 0.0.7).
