### PR TITLE
Publish to PyPI with CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,12 @@
+machine:
+  post:
+    - pyenv global 2.7.12 3.4.5
+
+deployment:
+  pypi:
+    owner: ouspg
+    tag: /^v[0-9.]+$/
+    commands:
+      - pip install twine
+      - python setup.py bdist_wheel --universal
+      - twine upload --username "$PYPI_USERNAME" --password "$PYPI_PASSWORD"

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   post:
-    - pyenv global 2.7.12 3.4.5
+    - pyenv global 2.7.12 3.4.5 3.5.2 pypy-5.3.1
 
 deployment:
   pypi:

--- a/circle.yml
+++ b/circle.yml
@@ -9,4 +9,4 @@ deployment:
     commands:
       - pip install twine
       - python setup.py bdist_wheel --universal
-      - twine upload --username "$PYPI_USERNAME" --password "$PYPI_PASSWORD" dist/*.whl
+      - twine upload --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" dist/*.whl

--- a/circle.yml
+++ b/circle.yml
@@ -9,4 +9,4 @@ deployment:
     commands:
       - pip install twine
       - python setup.py bdist_wheel --universal
-      - twine upload --username "$PYPI_USERNAME" --password "$PYPI_PASSWORD"
+      - twine upload --username "$PYPI_USERNAME" --password "$PYPI_PASSWORD" dist/*.whl

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ trytls = imp.load_module("trytls", *found)
 setup(
     name="trytls",
     version=trytls.__version__,
+    license="MIT",
+    url="https://github.com/ouspg/trytls",
     package_dir={"": "./runners"},
     packages=find_packages("./runners"),
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py34,py35,pypy
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py27,py35
+envlist = py27,py34
+skip_missing_interpreters = true
 
 [testenv]
 deps =


### PR DESCRIPTION
This pull request adds scaffolding needed for automatically running tests, building and deploying to PyPI using CircleCI.
- Add license and url keys to `setup.py`
- Modify `tox.ini` to run the tests for Python 2.7 and 3.4 (instead of 2.7 and 3.5) as these are the minimum required versions.
- Add `circle.yml` for running tox for every commit and building + deploying to PyPI for every tagged commit.
  - The tag regexp is /^v[0-9.]$/.
  - The PyPI username and password have to be given in CircleCI env variables PYPI_USERNAME and PYPI_PASSWORD.

Closes #90.
