### PR TITLE
Fine tune CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TryTLS
+# TryTLS [![CircleCI](https://circleci.com/gh/ouspg/trytls.svg?style=shield)](https://circleci.com/gh/ouspg/trytls)
 
 Does *your* library check TLS certificates properly?
 Broken certificate checks seems to be an overlooked issue.

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,7 @@
 machine:
   post:
     - pyenv install pypy-5.3
-    - pyenv install pypy3-2.4.0
-    - pyenv global 2.7.10 3.4.3 3.5.0 pypy-5.3 pypy3-2.4.0
+    - pyenv global 2.7.10 3.4.3 3.5.0 pypy-5.3
 
 deployment:
   pypi:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,pypy,pypy3
+envlist = py27,py34,py35,pypy
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,pypy
+envlist = py27,py34,py35,pypy,pypy3
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
This pull request contains minor modifications related to CI:
- Add a CircleCI status badge to the main README.md
- ~~Add `pypy3` to `tox.ini` environments~~
- Remove `pypy3` from tox.ini environments and `circle.yml`, as the current pypy3 version 2.4.0 is not yet Python 3.4 compatible (see http://doc.pypy.org/en/latest/release-pypy3-2.4.0.html).
