### PR TITLE
Test for TLS SNI support

### DIFF
--- a/runners/trytls/bundles/https.py
+++ b/runners/trytls/bundles/https.py
@@ -24,6 +24,16 @@ def badssl(accept, name, description):
 
 
 @testenv
+def badssl_sni(description):
+    yield Test(
+        accept=True,
+        description=description,
+        host="badssl.com",
+        port=443
+    )
+
+
+@testenv
 def badssl_onlymyca(description):
     _, _, cadata = gencert("localhost")
 
@@ -112,6 +122,7 @@ def local(accept, cn, description):
 
 
 badssl_tests = [
+    badssl_sni(description="support for TLS server name indication (SNI)"),
     badssl(False, "expired", "expired certificate"),
     badssl(False, "wrong.host", "wrong hostname in certificate"),
     badssl(False, "self-signed", "self-signed certificate"),


### PR DESCRIPTION
Test that server name indication (SNI) is supported as a first
test. This shows in result if rest of the BadSSL test results are
meaningful or not.

However, it would still be better if BadSSL tests are disabled due to
missing SNI support. See issue #75.
