### PR TITLE
Clarify passing arguments beginning with a hyphen to stubs

### DIFF
--- a/runners/trytls/bundles/__init__.py
+++ b/runners/trytls/bundles/__init__.py
@@ -1,0 +1,12 @@
+import pkg_resources
+
+
+def iter_bundles():
+    for entry in pkg_resources.iter_entry_points("trytls.bundles"):
+        yield entry.name
+
+
+def load_bundle(name):
+    for entry in pkg_resources.iter_entry_points("trytls.bundles", name):
+        return entry.load()
+    return None

--- a/runners/trytls/runner.py
+++ b/runners/trytls/runner.py
@@ -98,10 +98,10 @@ def collect(args, tests):
                 yield test, result.Skip(details=us.args[0])
             except UnexpectedOutput as uo:
                 output = uo.args[0].strip()
-                if not output:
-                    yield test, result.Error("no output")
-                elif output:
+                if output:
                     yield test, result.Error("unexpected output", output)
+                else:
+                    yield test, result.Error("no output")
             except ProcessFailed as pf:
                 yield test, result.Error("stub exited with return code {}".format(pf.args[0]), pf.args[1])
             else:

--- a/runners/trytls/runner.py
+++ b/runners/trytls/runner.py
@@ -3,10 +3,9 @@ from __future__ import print_function, unicode_literals
 import sys
 import argparse
 import subprocess
-import pkg_resources
 from colorama import Fore, Back, Style, init, AnsiToWin32
 
-from . import __version__, gencert, utils, result
+from . import __version__, gencert, utils, result, bundles
 
 
 # Initialize colorama without wrapping sys.stdout globally
@@ -186,15 +185,6 @@ def run(args, tests):
 
 
 def main():
-    def iter_bundles():
-        for entry in pkg_resources.iter_entry_points("trytls.bundles"):
-            yield entry.name
-
-    def load_bundle(name):
-        for entry in pkg_resources.iter_entry_points("trytls.bundles", name):
-            return entry.load()
-        return None
-
     try:
         openssl_version = gencert.openssl_version()
     except gencert.OpenSSLNotFound as err:
@@ -209,7 +199,7 @@ def main():
         metavar="BUNDLE",
         default=None,
         nargs="?",
-        type=load_bundle
+        type=bundles.load_bundle
     )
     parser.add_argument(
         "command",
@@ -227,8 +217,8 @@ def main():
 
     args = parser.parse_args()
     if args.bundle is None:
-        bundles = sorted(iter_bundles())
-        parser.error("missing the bundle argument\n\nValid bundle options:\n" + indent("\n".join(bundles), 2))
+        bundle_list = sorted(bundles.iter_bundles())
+        parser.error("missing the bundle argument\n\nValid bundle options:\n" + indent("\n".join(bundle_list), 2))
 
     if args.command is None:
         parser.error("too few arguments, missing command")

--- a/runners/trytls/runner.py
+++ b/runners/trytls/runner.py
@@ -2,7 +2,6 @@ from __future__ import print_function, unicode_literals
 
 import os
 import sys
-import errno
 import argparse
 import subprocess
 from colorama import Fore, Back, Style, init, AnsiToWin32


### PR DESCRIPTION
This pull request implements the option 2 outlined in pull request #83: Modify `trytls` so that everything after the first COMMAND argument is passed to the stub as-is.

Double dashes ('--') still work, but it should be noted that having them before the bundle name will not suppress handling of optional arguments after the bundle name. For example the following will still print the help text:

``` sh
 $ trytls -- https -h
```

However the following tries to load bundle named '-h' instead of displaying the help text:

``` sh
 $ trytls -- -h https
```

The following will attempt to execute command '-h' instead of displaying help:

``` sh
 $ trytls https -- -h
```

This PR also contains a couple of additional fixes:
- Tell the user that the bundle name was not valid when encountering an unknown bundle name.
  
  ``` sh
  $ trytls httpss
  usage: trytls bundle command [arg ...]
  trytls: error: unknown bundle 'httpss'
  ```
- Handle cases where the stub process couldn't be started at all.
  
  ``` sh
  $ trytls https pytthonz stubs/python-urllib2/run.py 
  platform: OS X 10.11.6
  runner: trytls 0.1.1 (CPython 2.7.12, OpenSSL 0.9.8zh)
  stub: pytthonz 'stubs/python-urllib2/run.py'
  ERROR support for TLS server name indication (SNI) [accept badssl.com:443]
       reason: failed to launch the stub
       output: No such file or directory 
  ERROR expired certificate [reject expired.badssl.com:443]
       reason: failed to launch the stub
       output: No such file or directory
  ...
  ```

Closes #83.
