### PR TITLE
Update stubs/erlang-* to the new calling convention

### DIFF
--- a/stubs/erlang-httpc/run
+++ b/stubs/erlang-httpc/run
@@ -30,10 +30,10 @@ start_deps() ->
     ssl:start().
  
 check({ok, _}) ->
-    io:format("VERIFY SUCCESS~n");
+    io:format("ACCEPT~n");
  
 check({error, _}) ->
-    io:format("VERIFY FAILURE~n");
+    io:format("REJECT~n");
  
 check(_) ->
-    io:format("VERIFY FAILURE~n").
+    io:format("REJECT~n").

--- a/stubs/erlang-ssl/run
+++ b/stubs/erlang-ssl/run
@@ -30,10 +30,10 @@ start_deps() ->
     ssl:start().
  
 check({ok, _}) ->
-    io:format("VERIFY SUCCESS~n");
+    io:format("ACCEPT~n");
  
 check({error, _}) ->
-    io:format("VERIFY FAILURE~n");
+    io:format("REJECT~n");
  
 check(_) ->
-    io:format("VERIFY FAILURE~n").
+    io:format("REJECT~n").


### PR DESCRIPTION
This pull request updates the Erlang stubs to the new v0.2.0 calling convention where **VERIFY SUCCESS** is replaced by **ACCEPT** and **VERIFY FAILURE** is replaced by **REJECT**.
