### PR TITLE
Added linux results to pure OS X-run stubs

### DIFF
--- a/stubs/bash-curl/results.txt
+++ b/stubs/bash-curl/results.txt
@@ -21,3 +21,27 @@ ERROR valid localhost certificate [accept localhost:55111]
       output: Error code: 56, for more info: https://curl.haxx.se/libcurl/c/libcurl-errors.html
  PASS invalid localhost certificate [reject localhost:55115]
  PASS use only the given CA bundle, not system's [reject sha256.badssl.com:443]
+
+ platform: Linux (Ubuntu 16.04)
+ runner: trytls 0.2.0 (CPython 2.7.11+, OpenSSL 1.0.2g-fips)
+ stub: bash run
+  PASS support for TLS server name indication (SNI) [accept badssl.com:443]
+  PASS expired certificate [reject expired.badssl.com:443]
+  PASS wrong hostname in certificate [reject wrong.host.badssl.com:443]
+  PASS self-signed certificate [reject self-signed.badssl.com:443]
+  PASS SHA-256 signature [accept sha256.badssl.com:443]
+  PASS 1000 subjectAltNames [accept 1000-sans.badssl.com:443]
+  PASS incomplete chain of trust [reject incomplete-chain.badssl.com:443]
+  PASS Superfish CA [reject superfish.badssl.com:443]
+  PASS eDellRoot CA [reject edellroot.badssl.com:443]
+  PASS DSDTestProvider CA [reject dsdtestprovider.badssl.com:443]
+  PASS protect against Apple's TLS vulnerability CVE-2014-1266 [reject www.ssllabs.com:10443]
+  PASS protect against the FREAK attack [reject www.ssllabs.com:10444]
+  PASS protect against the Logjam attack [reject www.ssllabs.com:10445]
+  PASS protect against FREAK attack (test server 1) [reject cve.freakattack.com:443]
+  PASS protect against FREAK attack (test server 2) [reject cve2.freakattack.com:443]
+ ERROR valid localhost certificate [accept localhost:33223]
+       reason: stub exited with return code 56
+       output: Error code: 56, for more info: https://curl.haxx.se/libcurl/c/libcurl-errors.html
+  PASS invalid localhost certificate [reject localhost:46742]
+  FAIL use only the given CA bundle, not system's [reject sha256.badssl.com:443]

--- a/stubs/bash-opensslSClient/results.txt
+++ b/stubs/bash-opensslSClient/results.txt
@@ -27,3 +27,25 @@ ERROR protect against FREAK attack (test server 2) [reject cve2.freakattack.com:
  PASS valid localhost certificate [accept localhost:55085]
  FAIL invalid localhost certificate [reject localhost:55087]
  FAIL use only the given CA bundle, not system's [reject sha256.badssl.com:443]
+
+ platform: Linux (Ubuntu 16.04)
+runner: trytls 0.2.0 (CPython 2.7.11+, OpenSSL 1.0.2g-fips)
+stub: bash run
+ PASS support for TLS server name indication (SNI) [accept badssl.com:443]
+ PASS expired certificate [reject expired.badssl.com:443]
+ FAIL wrong hostname in certificate [reject wrong.host.badssl.com:443]
+ PASS self-signed certificate [reject self-signed.badssl.com:443]
+ PASS SHA-256 signature [accept sha256.badssl.com:443]
+ PASS 1000 subjectAltNames [accept 1000-sans.badssl.com:443]
+ PASS incomplete chain of trust [reject incomplete-chain.badssl.com:443]
+ PASS Superfish CA [reject superfish.badssl.com:443]
+ PASS eDellRoot CA [reject edellroot.badssl.com:443]
+ PASS DSDTestProvider CA [reject dsdtestprovider.badssl.com:443]
+ FAIL protect against Apple's TLS vulnerability CVE-2014-1266 [reject www.ssllabs.com:10443]
+ FAIL protect against the FREAK attack [reject www.ssllabs.com:10444]
+ FAIL protect against the Logjam attack [reject www.ssllabs.com:10445]
+ FAIL protect against FREAK attack (test server 1) [reject cve.freakattack.com:443]
+ FAIL protect against FREAK attack (test server 2) [reject cve2.freakattack.com:443]
+ PASS valid localhost certificate [accept localhost:34164]
+ FAIL invalid localhost certificate [reject localhost:44426]
+ FAIL use only the given CA bundle, not system's [reject sha256.badssl.com:443]

--- a/stubs/lua5.1-luasec/results.txt
+++ b/stubs/lua5.1-luasec/results.txt
@@ -20,3 +20,26 @@ stub: 'lua5.1' 'stubs/lua5.1-luasec/run.lua'
  FAIL invalid localhost certificate [reject localhost:34955]
  PASS use only the given CA bundle, not system's [reject sha256.badssl.com:443]
       output: certificate verify failed
+
+  platform: Linux (Ubuntu 16.04)
+  runner: trytls 0.2.0 (CPython 2.7.11+, OpenSSL 1.0.2g-fips)
+  stub: 'lua5.1' 'run.lua'
+   SKIP support for TLS server name indication (SNI) [accept badssl.com:443]
+   SKIP expired certificate [reject expired.badssl.com:443]
+   SKIP wrong hostname in certificate [reject wrong.host.badssl.com:443]
+   SKIP self-signed certificate [reject self-signed.badssl.com:443]
+   SKIP SHA-256 signature [accept sha256.badssl.com:443]
+   SKIP 1000 subjectAltNames [accept 1000-sans.badssl.com:443]
+   SKIP incomplete chain of trust [reject incomplete-chain.badssl.com:443]
+   SKIP Superfish CA [reject superfish.badssl.com:443]
+   SKIP eDellRoot CA [reject edellroot.badssl.com:443]
+   SKIP DSDTestProvider CA [reject dsdtestprovider.badssl.com:443]
+   SKIP protect against Apple's TLS vulnerability CVE-2014-1266 [reject www.ssllabs.com:10443]
+   SKIP protect against the FREAK attack [reject www.ssllabs.com:10444]
+   SKIP protect against the Logjam attack [reject www.ssllabs.com:10445]
+   SKIP protect against FREAK attack (test server 1) [reject cve.freakattack.com:443]
+   SKIP protect against FREAK attack (test server 2) [reject cve2.freakattack.com:443]
+   PASS valid localhost certificate [accept localhost:34655]
+   FAIL invalid localhost certificate [reject localhost:34816]
+   PASS use only the given CA bundle, not system's [reject sha256.badssl.com:443]
+        output: certificate verify failed

--- a/stubs/php-file-get-contents/results.txt
+++ b/stubs/php-file-get-contents/results.txt
@@ -19,3 +19,25 @@ stub: './run.php'
  SKIP valid localhost certificate [accept localhost:55427]
  SKIP invalid localhost certificate [reject localhost:55428]
  SKIP use only the given CA bundle, not system's [reject sha256.badssl.com:443]
+
+ platform: Linux (Ubuntu 16.04)
+ runner: trytls 0.2.0 (CPython 2.7.11+, OpenSSL 1.0.2g-fips)
+ stub: './run.php'
+  PASS support for TLS server name indication (SNI) [accept badssl.com:443]
+  PASS expired certificate [reject expired.badssl.com:443]
+  PASS wrong hostname in certificate [reject wrong.host.badssl.com:443]
+  PASS self-signed certificate [reject self-signed.badssl.com:443]
+  PASS SHA-256 signature [accept sha256.badssl.com:443]
+  PASS 1000 subjectAltNames [accept 1000-sans.badssl.com:443]
+  PASS incomplete chain of trust [reject incomplete-chain.badssl.com:443]
+  PASS Superfish CA [reject superfish.badssl.com:443]
+  PASS eDellRoot CA [reject edellroot.badssl.com:443]
+  PASS DSDTestProvider CA [reject dsdtestprovider.badssl.com:443]
+  PASS protect against Apple's TLS vulnerability CVE-2014-1266 [reject www.ssllabs.com:10443]
+  PASS protect against the FREAK attack [reject www.ssllabs.com:10444]
+  PASS protect against the Logjam attack [reject www.ssllabs.com:10445]
+  PASS protect against FREAK attack (test server 1) [reject cve.freakattack.com:443]
+  PASS protect against FREAK attack (test server 2) [reject cve2.freakattack.com:443]
+  SKIP valid localhost certificate [accept localhost:41650]
+  SKIP invalid localhost certificate [reject localhost:46619]
+  SKIP use only the given CA bundle, not system's [reject sha256.badssl.com:443]

--- a/stubs/python-idiokit/results.txt
+++ b/stubs/python-idiokit/results.txt
@@ -19,3 +19,25 @@ stub: python 'run.py'
  PASS valid localhost certificate [accept localhost:53907]
  PASS invalid localhost certificate [reject localhost:53909]
  PASS use only the given CA bundle, not system's [reject sha256.badssl.com:443]
+
+ platform: Linux (Ubuntu 16.04)
+ runner: trytls 0.2.0 (CPython 2.7.11+, OpenSSL 1.0.2g-fips)
+ stub: python 'run.py'
+  FAIL support for TLS server name indication (SNI) [accept badssl.com:443]
+  PASS expired certificate [reject expired.badssl.com:443]
+  PASS wrong hostname in certificate [reject wrong.host.badssl.com:443]
+  PASS self-signed certificate [reject self-signed.badssl.com:443]
+  FAIL SHA-256 signature [accept sha256.badssl.com:443]
+  FAIL 1000 subjectAltNames [accept 1000-sans.badssl.com:443]
+  PASS incomplete chain of trust [reject incomplete-chain.badssl.com:443]
+  PASS Superfish CA [reject superfish.badssl.com:443]
+  PASS eDellRoot CA [reject edellroot.badssl.com:443]
+  PASS DSDTestProvider CA [reject dsdtestprovider.badssl.com:443]
+  PASS protect against Apple's TLS vulnerability CVE-2014-1266 [reject www.ssllabs.com:10443]
+  PASS protect against the FREAK attack [reject www.ssllabs.com:10444]
+  PASS protect against the Logjam attack [reject www.ssllabs.com:10445]
+  PASS protect against FREAK attack (test server 1) [reject cve.freakattack.com:443]
+  PASS protect against FREAK attack (test server 2) [reject cve2.freakattack.com:443]
+  PASS valid localhost certificate [accept localhost:39451]
+  PASS invalid localhost certificate [reject localhost:37673]
+  PASS use only the given CA bundle, not system's [reject sha256.badssl.com:443]

--- a/stubs/python-requests/results.txt
+++ b/stubs/python-requests/results.txt
@@ -21,3 +21,27 @@ stub: python 'run.py'
  PASS invalid localhost certificate [reject localhost:53887]
       output: /Library/Python/2.7/site-packages/requests/packages/urllib3/connection.py:303: SubjectAltNameWarning: Certificate for localhost has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818. (See https://github.com/shazow/urllib3/issues/497 for details.)  SubjectAltNameWarning
  FAIL use only the given CA bundle, not system's [reject sha256.badssl.com:443]
+
+ platform: Linux (Ubuntu 16.04)
+ runner: trytls 0.2.0 (CPython 2.7.11+, OpenSSL 1.0.2g-fips)
+ stub: python 'run.py'
+  PASS support for TLS server name indication (SNI) [accept badssl.com:443]
+  PASS expired certificate [reject expired.badssl.com:443]
+  PASS wrong hostname in certificate [reject wrong.host.badssl.com:443]
+  PASS self-signed certificate [reject self-signed.badssl.com:443]
+  PASS SHA-256 signature [accept sha256.badssl.com:443]
+  PASS 1000 subjectAltNames [accept 1000-sans.badssl.com:443]
+  PASS incomplete chain of trust [reject incomplete-chain.badssl.com:443]
+  PASS Superfish CA [reject superfish.badssl.com:443]
+  PASS eDellRoot CA [reject edellroot.badssl.com:443]
+  PASS DSDTestProvider CA [reject dsdtestprovider.badssl.com:443]
+  PASS protect against Apple's TLS vulnerability CVE-2014-1266 [reject www.ssllabs.com:10443]
+  PASS protect against the FREAK attack [reject www.ssllabs.com:10444]
+  PASS protect against the Logjam attack [reject www.ssllabs.com:10445]
+  PASS protect against FREAK attack (test server 1) [reject cve.freakattack.com:443]
+  PASS protect against FREAK attack (test server 2) [reject cve2.freakattack.com:443]
+  PASS valid localhost certificate [accept localhost:33472]
+       output: /usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/connection.py:303: SubjectAltNameWarning: Certificate for localhost has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818. (See https://github.com/shazow/urllib3/issues/497 for details.)  SubjectAltNameWarning
+  PASS invalid localhost certificate [reject localhost:43449]
+       output: /usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/connection.py:303: SubjectAltNameWarning: Certificate for localhost has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818. (See https://github.com/shazow/urllib3/issues/497 for details.)  SubjectAltNameWarning
+  PASS use only the given CA bundle, not system's [reject sha256.badssl.com:443]

--- a/stubs/python-urllib2/results.txt
+++ b/stubs/python-urllib2/results.txt
@@ -19,3 +19,25 @@ stub: python 'run.py'
  PASS valid localhost certificate [accept localhost:53855]
  PASS invalid localhost certificate [reject localhost:53859]
  FAIL use only the given CA bundle, not system's [reject sha256.badssl.com:443]
+
+ platform: Linux (Ubuntu 16.04)
+ runner: trytls 0.2.0 (CPython 2.7.11+, OpenSSL 1.0.2g-fips)
+ stub: python 'run.py'
+  PASS support for TLS server name indication (SNI) [accept badssl.com:443]
+  PASS expired certificate [reject expired.badssl.com:443]
+  PASS wrong hostname in certificate [reject wrong.host.badssl.com:443]
+  PASS self-signed certificate [reject self-signed.badssl.com:443]
+  PASS SHA-256 signature [accept sha256.badssl.com:443]
+  PASS 1000 subjectAltNames [accept 1000-sans.badssl.com:443]
+  PASS incomplete chain of trust [reject incomplete-chain.badssl.com:443]
+  PASS Superfish CA [reject superfish.badssl.com:443]
+  PASS eDellRoot CA [reject edellroot.badssl.com:443]
+  PASS DSDTestProvider CA [reject dsdtestprovider.badssl.com:443]
+  PASS protect against Apple's TLS vulnerability CVE-2014-1266 [reject www.ssllabs.com:10443]
+  PASS protect against the FREAK attack [reject www.ssllabs.com:10444]
+  PASS protect against the Logjam attack [reject www.ssllabs.com:10445]
+  PASS protect against FREAK attack (test server 1) [reject cve.freakattack.com:443]
+  PASS protect against FREAK attack (test server 2) [reject cve2.freakattack.com:443]
+  PASS valid localhost certificate [accept localhost:42470]
+  PASS invalid localhost certificate [reject localhost:41419]
+  PASS use only the given CA bundle, not system's [reject sha256.badssl.com:443]

--- a/stubs/python-urllib3/results.txt
+++ b/stubs/python-urllib3/results.txt
@@ -31,3 +31,40 @@ stub: python 'run.py'
  PASS invalid localhost certificate [reject localhost:53819]
       output: /Users/mamietti/Library/Python/2.7/lib/python/site-packages/urllib3/connection.py:303: SubjectAltNameWarning: Certificate for localhost has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818. (See https://github.com/shazow/urllib3/issues/497 for details.)  SubjectAltNameWarninghostname 'localhost' doesn't match u'nothing'
  FAIL use only the given CA bundle, not system's [reject sha256.badssl.com:443]
+
+ platform: Linux (Ubuntu 16.04)
+ runner: trytls 0.2.0 (CPython 2.7.11+, OpenSSL 1.0.2g-fips)
+ stub: python 'run.py'
+  PASS support for TLS server name indication (SNI) [accept badssl.com:443]
+  PASS expired certificate [reject expired.badssl.com:443]
+       output: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
+  PASS wrong hostname in certificate [reject wrong.host.badssl.com:443]
+       output: hostname 'wrong.host.badssl.com' doesn't match either of '*.badssl.com', 'badssl.com'
+  PASS self-signed certificate [reject self-signed.badssl.com:443]
+       output: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
+  PASS SHA-256 signature [accept sha256.badssl.com:443]
+  PASS 1000 subjectAltNames [accept 1000-sans.badssl.com:443]
+  PASS incomplete chain of trust [reject incomplete-chain.badssl.com:443]
+       output: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
+  PASS Superfish CA [reject superfish.badssl.com:443]
+       output: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
+  PASS eDellRoot CA [reject edellroot.badssl.com:443]
+       output: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
+  PASS DSDTestProvider CA [reject dsdtestprovider.badssl.com:443]
+       output: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
+  PASS protect against Apple's TLS vulnerability CVE-2014-1266 [reject www.ssllabs.com:10443]
+       output: [SSL: BAD_SIGNATURE] bad signature (_ssl.c:590)
+  PASS protect against the FREAK attack [reject www.ssllabs.com:10444]
+       output: [SSL: UNEXPECTED_MESSAGE] unexpected message (_ssl.c:590)
+  PASS protect against the Logjam attack [reject www.ssllabs.com:10445]
+       output: [SSL: SSL_NEGATIVE_LENGTH] dh key too small (_ssl.c:590)
+  PASS protect against FREAK attack (test server 1) [reject cve.freakattack.com:443]
+       output: [SSL: UNEXPECTED_MESSAGE] unexpected message (_ssl.c:590)
+  PASS protect against FREAK attack (test server 2) [reject cve2.freakattack.com:443]
+       output: [SSL: UNEXPECTED_MESSAGE] unexpected message (_ssl.c:590)
+  PASS valid localhost certificate [accept localhost:41674]
+       output: /usr/lib/python2.7/dist-packages/urllib3/connection.py:266: SubjectAltNameWarning: Certificate for localhost has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818. (See https://github.com/shazow/urllib3/issues/497 for details.)  SubjectAltNameWarning
+  PASS invalid localhost certificate [reject localhost:40815]
+       output: /usr/lib/python2.7/dist-packages/urllib3/connection.py:266: SubjectAltNameWarning: Certificate for localhost has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818. (See https://github.com/shazow/urllib3/issues/497 for details.)  SubjectAltNameWarninghostname 'localhost' doesn't match u'nothing'
+  PASS use only the given CA bundle, not system's [reject sha256.badssl.com:443]
+       output: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)

--- a/stubs/python3-urllib/results.txt
+++ b/stubs/python3-urllib/results.txt
@@ -19,3 +19,25 @@ stub: python3 'run.py'
  PASS valid localhost certificate [accept localhost:53766]
  PASS invalid localhost certificate [reject localhost:53768]
  FAIL use only the given CA bundle, not system's [reject sha256.badssl.com:443]
+
+ platform: Linux (Ubuntu 16.04)
+ runner: trytls 0.2.0 (CPython 2.7.11+, OpenSSL 1.0.2g-fips)
+ stub: python3 'run.py'
+  PASS support for TLS server name indication (SNI) [accept badssl.com:443]
+  PASS expired certificate [reject expired.badssl.com:443]
+  PASS wrong hostname in certificate [reject wrong.host.badssl.com:443]
+  PASS self-signed certificate [reject self-signed.badssl.com:443]
+  PASS SHA-256 signature [accept sha256.badssl.com:443]
+  PASS 1000 subjectAltNames [accept 1000-sans.badssl.com:443]
+  PASS incomplete chain of trust [reject incomplete-chain.badssl.com:443]
+  PASS Superfish CA [reject superfish.badssl.com:443]
+  PASS eDellRoot CA [reject edellroot.badssl.com:443]
+  PASS DSDTestProvider CA [reject dsdtestprovider.badssl.com:443]
+  PASS protect against Apple's TLS vulnerability CVE-2014-1266 [reject www.ssllabs.com:10443]
+  PASS protect against the FREAK attack [reject www.ssllabs.com:10444]
+  PASS protect against the Logjam attack [reject www.ssllabs.com:10445]
+  PASS protect against FREAK attack (test server 1) [reject cve.freakattack.com:443]
+  PASS protect against FREAK attack (test server 2) [reject cve2.freakattack.com:443]
+  PASS valid localhost certificate [accept localhost:46077]
+  PASS invalid localhost certificate [reject localhost:40467]
+  PASS use only the given CA bundle, not system's [reject sha256.badssl.com:443]


### PR DESCRIPTION
Due to the OS X OpenSSL being a bit peculiar, I had to recheck those stubs that do not offer a docker container and use OpenSSL.
