### PR TITLE
Made mandatory to use Mozilla CA bundle in Lua stub

### DIFF
--- a/stubs/lua5.1-luasec/README.md
+++ b/stubs/lua5.1-luasec/README.md
@@ -17,14 +17,11 @@ Luarocks installed and used to install
 * luasec 0.6-1 or newer (`luarocks install luasec` to command line)
 * luasocket (`luarocks install luasocket` to command line)
 
-Certificate file in this (trytls/stubs/lua5.1-luasec/) directory from https://curl.haxx.se/docs/caextract.html
-
-Tested on Ubuntu 16.04
+Certificate file in this directory from https://curl.haxx.se/docs/caextract.html
 
 # Credits
 
 http://notebook.kulchenko.com/programming/https-ssl-calls-with-lua-and-luasec
-https://github.com/brunoos/luasec/pull/49/commits/cde151739e4f7d9262dcea462a2e58d708501ad8
 
 # Luasec License
 

--- a/stubs/lua5.1-luasec/README.md
+++ b/stubs/lua5.1-luasec/README.md
@@ -12,10 +12,12 @@ REJECT
 
 # Dependencies:
 
-Lua 5.1 or newer installed
+Lua 5.1 installed
 Luarocks installed and used to install
 * luasec 0.6-1 or newer (`luarocks install luasec` to command line)
 * luasocket (`luarocks install luasocket` to command line)
+
+Certificate file in this (trytls/stubs/lua5.1-luasec/) directory from https://curl.haxx.se/docs/caextract.html
 
 Tested on Ubuntu 16.04
 

--- a/stubs/lua5.1-luasec/results.txt
+++ b/stubs/lua5.1-luasec/results.txt
@@ -1,22 +1,33 @@
 platform: Linux (Ubuntu 16.04)
 runner: trytls 0.2.0 (CPython 2.7.11+, OpenSSL 1.0.2g-fips)
-stub: 'lua5.1' 'stubs/lua5.1-luasec/run.lua'
- SKIP support for TLS server name indication (SNI) [accept badssl.com:443]
- SKIP expired certificate [reject expired.badssl.com:443]
- SKIP wrong hostname in certificate [reject wrong.host.badssl.com:443]
- SKIP self-signed certificate [reject self-signed.badssl.com:443]
- SKIP SHA-256 signature [accept sha256.badssl.com:443]
- SKIP 1000 subjectAltNames [accept 1000-sans.badssl.com:443]
- SKIP incomplete chain of trust [reject incomplete-chain.badssl.com:443]
- SKIP Superfish CA [reject superfish.badssl.com:443]
- SKIP eDellRoot CA [reject edellroot.badssl.com:443]
- SKIP DSDTestProvider CA [reject dsdtestprovider.badssl.com:443]
- SKIP protect against Apple's TLS vulnerability CVE-2014-1266 [reject www.ssllabs.com:10443]
- SKIP protect against the FREAK attack [reject www.ssllabs.com:10444]
- SKIP protect against the Logjam attack [reject www.ssllabs.com:10445]
- SKIP protect against FREAK attack (test server 1) [reject cve.freakattack.com:443]
- SKIP protect against FREAK attack (test server 2) [reject cve2.freakattack.com:443]
- PASS valid localhost certificate [accept localhost:38085]
- FAIL invalid localhost certificate [reject localhost:34955]
+stub: 'lua5.1' 'run.lua'
+ PASS support for TLS server name indication (SNI) [accept badssl.com:443]
+ PASS expired certificate [reject expired.badssl.com:443]
+      output: certificate verify failed
+ FAIL wrong hostname in certificate [reject wrong.host.badssl.com:443]
+ PASS self-signed certificate [reject self-signed.badssl.com:443]
+      output: certificate verify failed
+ PASS SHA-256 signature [accept sha256.badssl.com:443]
+ PASS 1000 subjectAltNames [accept 1000-sans.badssl.com:443]
+ PASS incomplete chain of trust [reject incomplete-chain.badssl.com:443]
+      output: certificate verify failed
+ PASS Superfish CA [reject superfish.badssl.com:443]
+      output: certificate verify failed
+ PASS eDellRoot CA [reject edellroot.badssl.com:443]
+      output: certificate verify failed
+ PASS DSDTestProvider CA [reject dsdtestprovider.badssl.com:443]
+      output: certificate verify failed
+ PASS protect against Apple's TLS vulnerability CVE-2014-1266 [reject www.ssllabs.com:10443]
+      output: bad signature
+ PASS protect against the FREAK attack [reject www.ssllabs.com:10444]
+      output: unexpected message
+ PASS protect against the Logjam attack [reject www.ssllabs.com:10445]
+      output: dh key too small
+ PASS protect against FREAK attack (test server 1) [reject cve.freakattack.com:443]
+      output: unexpected message
+ PASS protect against FREAK attack (test server 2) [reject cve2.freakattack.com:443]
+      output: unexpected message
+ PASS valid localhost certificate [accept localhost:41062]
+ FAIL invalid localhost certificate [reject localhost:35745]
  PASS use only the given CA bundle, not system's [reject sha256.badssl.com:443]
       output: certificate verify failed

--- a/stubs/lua5.1-luasec/run.lua
+++ b/stubs/lua5.1-luasec/run.lua
@@ -1,6 +1,5 @@
 local socket = require "socket"
 local ssl = require "ssl"
---local apr = require "apr"
 
 function tablelength(T)
     local count = 0
@@ -9,37 +8,38 @@ function tablelength(T)
 end
 
 function main()
+    cert = nil
     if tablelength(arg)==5 then
         cert = arg[3]
-
-        local params = {
-            mode = "client",
-            protocol = "any",
-            verify = "peer",
-            options = "all",
-            cafile = cert
-        }
-
-        local conn = socket.tcp()
-        conn:connect(arg[1], arg[2])
-
-        conn = ssl.wrap(conn, params)
-        conn:sni(arg[1])
-        local succ,err = conn:dohandshake()
-
-        if succ then
-            print("ACCEPT")
-        else
-            print(err)
-            print("REJECT")
-        end
-        conn:close()
     elseif tablelength(arg) == 4 then
-        print("UNSUPPORTED")
+        cert = string.format("%s/cacert.pem", io.popen("pwd"):read())
     else
         print(string.format( "Usage: %s <HOST> <PORT> (<CA-BUNDLE>)", arg[0] ))
         os.exit(1)
     end
+
+    local params = {
+        mode = "client",
+        protocol = "any",
+        verify = "peer",
+        options = "all",
+        cafile = cert
+    }
+
+    local conn = socket.tcp()
+    conn:connect(arg[1], arg[2])
+
+    conn = ssl.wrap(conn, params)
+    conn:sni(arg[1])
+    local succ,err = conn:dohandshake()
+
+    if succ then
+        print("ACCEPT")
+    else
+        print(err)
+        print("REJECT")
+    end
+    conn:close()
 end
 
 main()


### PR DESCRIPTION
Luasec does not have a built-in way to find the systems default CA bundle, so I used the advice from http://notebook.kulchenko.com/programming/https-ssl-calls-with-lua-and-luasec.
