### PR TITLE
trytls 'plug-in' for ca-bundles

### DIFF
--- a/others/BP/README.md
+++ b/others/BP/README.md
@@ -10,7 +10,7 @@ Currently (for example):
 
 ## Setup
 
-Move the bp-script into /bin folder.
+Move the bp-script into .../bin folder.
 
 ```
 $ trytls https bp "python3 run.py" /etc/ssl/certs/ca-certificates.crt

--- a/others/BP/README.md
+++ b/others/BP/README.md
@@ -1,0 +1,21 @@
+# Usage:
+
+## Intro
+
+This script can be used with trytls-runner.
+It allows you to run also the stubs that cannot be ran without ca-bundle.
+Currently (for example):
+  * lua5.1-luasec
+  * c-openssl
+
+## Setup
+
+Move the bp-script into /bin folder.
+
+```
+$ trytls https bp "python3 run.py" /etc/ssl/certs/ca-certificates.crt
+...
+
+$ trytls https bp "lua5.1 run.lua" /etc/ssl/certs/ca-certificates.crt
+...
+```

--- a/others/BP/bp
+++ b/others/BP/bp
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [[ ! $1 ]]; then
+  echo Usage: trytls https bp "python3 run.py" /etc/ssl/ca-certificates.crt
+  exit 1
+fi
+
+cmdf=$1     #for example: "python3 run.py"
+ca=$2       #ca, from command line, for example: "/etc/ssl/certs/ca-certificates.crt"
+host=$3
+port=$4
+tca=$5      #ca, by trytls-runner
+if [[ $tca ]]; then
+  ca=$tca
+fi
+
+eval $cmdf $host $port $ca
+exit $?

--- a/others/BP/bp
+++ b/others/BP/bp
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ ! $1 ]]; then
-  echo Usage: trytls https bp <command file> <ca-bundle>
+  echo "Usage: trytls https bp <command file> <ca-bundle>"
   exit 1
 fi
 

--- a/others/BP/bp
+++ b/others/BP/bp
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ ! $1 ]]; then
-  echo Usage: trytls https bp "python3 run.py" /etc/ssl/ca-certificates.crt
+  echo Usage: trytls https bp <command file> <ca-bundle>
   exit 1
 fi
 


### PR DESCRIPTION
- This is just a proposal. This does not have to be accepted if not wanted.
- Simple way to allow the usage of 'external' ca-bundles when using trytls-runner.
