### PR TITLE
Fix Python 3 compatibility and add a sanity check to tox.ini

### DIFF
--- a/runners/trytls/bundles/https.py
+++ b/runners/trytls/bundles/https.py
@@ -16,7 +16,7 @@ except ImportError:
     from http.server import HTTPServer, BaseHTTPRequestHandler
 
 
-BADTLS_CA_DATA = """
+BADTLS_CA_DATA = b"""
 -----BEGIN CERTIFICATE-----
 MIIDlTCCAn+gAwIBAgIIVvpPzLyqk+0wCwYJKoZIhvcNAQELMGoxaDAJBgNVBAYT
 AlVTMBQGA1UECAwNTWFzc2FjaHVzZXR0czAOBgNVBAcMB05ld2J1cnkwFgYDVQQK
@@ -43,7 +43,7 @@ WQ77yy6bOvcJh4heqtIJuYg5F3vhvSGo4i5Bkx+daRKFzFwsoiexgRNTdlPCEGsQ
 
 
 def _split_address(address):
-    """
+    r"""
     Return (host, port) split from a string in form of "host:port".
     The host part is returned as a string, port as int.
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
 commands =
   flake8 runners/trytls
   py.test runners/trytls
+  trytls https python -c 'print("UNSUPPORTED")'
 
 [pytest]
 addopts = --doctest-modules


### PR DESCRIPTION
Pull request #157 broke Python 3 compatibility, because the added `BADTLS_CA_DATA` string wasn't explicitly defined to be a byte string. Therefore the string was unicode in Python 3. This in turn caused `utils.tmpfiles`, which expects byte input, to crash.

This pull request fixes the issue and also adds a simple sanity check to `tox.ini`. After `py.test` tests `tox` now tests a trivial stub (that skips all tests) with `trytls` and checks that the tool doesn't at least crash.
