### PR TITLE
Use pipes.quote instead of shlex.quote in Python 2.7

### DIFF
--- a/runners/trytls/utils.py
+++ b/runners/trytls/utils.py
@@ -9,22 +9,23 @@ import functools
 import contextlib
 
 try:
-    from shlex import quote as _shlex_quote
+    from shlex import quote as _quote
 except ImportError:
-    # The following is a naive implementation of shlex.quote for Python 2.7, as
-    # shlex.quote was introduced in Python 3.3.
-    def _shlex_quote(string):
-        if string.isalnum():
-            return string
-        return "'" + string.replace("'", "\\'") + "'"
+    # shlex.quote was introduced in Python 3.3, use pipes.quote
+    # for Python 2.7.
+    from pipes import quote as _quote
 
 
 def format_command(args):
     r"""
     Return a list of argument strings as one shell-escaped command.
+
+    >>> import shlex
+    >>> shlex.split(format_command(["echo", "Hello, World!", "'quoted'"]))
+    ['echo', 'Hello, World!', "'quoted'"]
     """
 
-    return " ".join(_shlex_quote(arg) for arg in args)
+    return " ".join(_quote(arg) for arg in args)
 
 
 def python_info():


### PR DESCRIPTION
TryTLS uses [`shlex.quote`](https://docs.python.org/3.3/library/shlex.html#shlex.quote) to format the stub command in the tool's output headers. TryTLS implemented also implemented its own replacement because `shlex.quote` didn't yet exist on Python 2.7.

This pull request removes the simplistic and incorrect `shlex.quote` replacement, opting to use [`pipes.quote`](https://docs.python.org/2/library/pipes.html#pipes.quote) instead on Python 2.7. The result should be more correct while looking nicer in most cases.

Also include a doctest for `utils.format_command`.
