### PR TITLE
Shootout - fedora24 - consistency update

### DIFF
--- a/shootout/fedora24/Dockerfile
+++ b/shootout/fedora24/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:24
 
 RUN dnf install git-all tar -y
 RUN pip install trytls


### PR DESCRIPTION
- Use fedora:24 instead of fedora:latest in dockerfile
- Tested that the image builds and correct version of fedora is used

```
$ docker run -ti --rm fedora24-trytls-001 cat /etc/redhat-release
Fedora release 24 (Twenty Four)
```
