### PR TITLE
c-libressl: Fix two buffer over read errors

### DIFF
--- a/stubs/c-libressl/run.c
+++ b/stubs/c-libressl/run.c
@@ -16,9 +16,6 @@ int main(int argc, char **argv) {
         char read_buf[1024];
         int exit_value = EXIT_SUCCESS;
 
-        write_buf[0] = '\0';
-        read_buf[0]  = '\0';
-
         if (argc < 3 || argc > 4) {
                 printf("%s <host> <port> [ca-bundle]\n", argv[0]);
                 return EXIT_FAILURE;

--- a/stubs/c-libressl/run.c
+++ b/stubs/c-libressl/run.c
@@ -71,8 +71,9 @@ int main(int argc, char **argv) {
                  "%s\r\n%s: %s\r\n\r\n",
                  "GET / HTTP/1.0",
                  "Host", host);
-        if (tls_write(context, write_buf, strlen(write_buf)) == -1)
+        if (tls_write(context, write_buf, strlen(write_buf)) == -1) {
                 err(1, "tls_write");
+        }
 
         /* Read HTTP GET response */
         if (tls_read(context, read_buf, sizeof(read_buf)) == -1) {

--- a/stubs/c-libressl/run.c
+++ b/stubs/c-libressl/run.c
@@ -79,22 +79,16 @@ int main(int argc, char **argv) {
                 err(1, "tls_read");
         }
 
-        if ((size_t)len < sizeof(read_buf)) {
-                read_buf[len] = '\0';
-        } else {
-                read_buf[sizeof(read_buf)-1] = '\0';
-        }
-
         /* We only care about the first line from HTTP GET response */
         for (size_t i=0; i < (size_t)len; i++) {
-                if (read_buf[i] == '\n') {
-                        read_buf[i] = '\0';
+                if (read_buf[i] == '\r' || read_buf[i] == '\n') {
+                        len = (ssize_t)i;
                         break;
                 }
         }
 
-        printf("%s\n", read_buf);
-        printf("ACCEPT\n");
+        fwrite(read_buf, sizeof(char), (size_t)len, stdout);
+        printf("\nACCEPT\n");
         exit_value = EXIT_SUCCESS;
 
  cleanup:

--- a/stubs/c-libressl/run.c
+++ b/stubs/c-libressl/run.c
@@ -85,6 +85,11 @@ int main(int argc, char **argv) {
                         len = (ssize_t)i;
                         break;
                 }
+
+                /* Filter away non-ASCII charaters */
+                if (read_buf[i] < 0x20 || read_buf[i] > 0x7f) {
+                        read_buf[i] = '?';
+                }
         }
 
         fwrite(read_buf, sizeof(char), (size_t)len, stdout);

--- a/stubs/c-libressl/run.c
+++ b/stubs/c-libressl/run.c
@@ -14,6 +14,7 @@ int main(int argc, char **argv) {
         char *ca_file = NULL;
         char write_buf[1024];
         char read_buf[1024];
+        ssize_t len;
         int exit_value = EXIT_SUCCESS;
 
         if (argc < 3 || argc > 4) {
@@ -73,12 +74,19 @@ int main(int argc, char **argv) {
         }
 
         /* Read HTTP GET response */
-        if (tls_read(context, read_buf, sizeof(read_buf)) == -1) {
+        len = tls_read(context, read_buf, sizeof(read_buf));
+        if (len < 0) {
                 err(1, "tls_read");
         }
 
+        if ((size_t)len < sizeof(read_buf)) {
+                read_buf[len] = '\0';
+        } else {
+                read_buf[sizeof(read_buf)-1] = '\0';
+        }
+
         /* We only care about the first line from HTTP GET response */
-        for (size_t i=0; i < strlen(read_buf); i++) {
+        for (size_t i=0; i < (size_t)len; i++) {
                 if (read_buf[i] == '\n') {
                         read_buf[i] = '\0';
                         break;


### PR DESCRIPTION
tls_read() doesn't null terminate buffer. Lets add it ourselves. Now the following for-loop and printf() won't over read the buffer.

Fixes #193.
