### PR TITLE
Made tlsfun demand SNI and refactored misc tests

### DIFF
--- a/runners/trytls/bundles/https.py
+++ b/runners/trytls/bundles/https.py
@@ -244,7 +244,7 @@ def local(accept, cn, description):
 
 
 @testgroup
-def sni_tests():
+def badssl_tests():
     forced_result = None
 
     res = yield Test(
@@ -274,7 +274,34 @@ def sni_tests():
         badssl(False, "incomplete-chain", "incomplete chain of trust", forced_result),
         badssl(False, "superfish", "Superfish CA", forced_result),
         badssl(False, "edellroot", "eDellRoot CA", forced_result),
-        badssl(False, "dsdtestprovider", "DSDTestProvider CA", forced_result),
+        badssl(False, "dsdtestprovider", "DSDTestProvider CA", forced_result)
+    )
+
+
+@testgroup
+def tlsfun_tests():
+    forced_result = None
+
+    res = yield Test(
+        accept=True,
+        description="support for TLS server name indication (SNI)",
+        host="tlsfun.de",
+        port=443
+    )
+    if res.type != results.Pass:
+        forced_result = results.Skip("could not detect SNI support")
+
+    res = yield Test(
+        accept=False,
+        description="self-signed certificate",
+        host="self-signed.badssl.com",
+        port=443,
+        forced_result=forced_result
+    )
+    if res.type != results.Pass and not forced_result:
+        forced_result = results.Skip("stub didn't reject a self-signed certificate")
+
+    yield testgroup(
         tlsfun(False, "badcert-edell", "eDellRoot CA #2", forced_result)
     )
 
@@ -321,7 +348,8 @@ all_tests = testgroup(
     ssllabs_tests,
     freakattack_tests,
     dshield_tests,
-    sni_tests,
+    badssl_tests,
+    tlsfun_tests,
     badtls_tests,
     local_tests
 )

--- a/runners/trytls/bundles/https.py
+++ b/runners/trytls/bundles/https.py
@@ -158,16 +158,6 @@ def freakattack(host, description):
 
 
 @testenv
-def dshield(accept, host, description):
-    yield Test(
-        accept=accept,
-        description=description,
-        host=host + ".dshield.org",
-        port=443
-    )
-
-
-@testenv
 def tlsfun(accept, name, description, forced_result):
     yield Test(
         accept=accept,
@@ -294,7 +284,7 @@ def tlsfun_tests():
     res = yield Test(
         accept=False,
         description="self-signed certificate",
-        host="self-signed.badssl.com",
+        host="expired.tlsfun.de",
         port=443,
         forced_result=forced_result
     )
@@ -341,7 +331,12 @@ local_tests = testgroup(
 )
 
 dshield_tests = testgroup(
-    dshield(False, "sslv3", "protection against POODLE attack")
+    Test(
+        accept="sslv3",
+        description="protection against POODLE attack",
+        host="sslv3.dshield.org",
+        port=443
+    )
 )
 
 all_tests = testgroup(

--- a/runners/trytls/bundles/https.py
+++ b/runners/trytls/bundles/https.py
@@ -158,12 +158,23 @@ def freakattack(host, description):
 
 
 @testenv
-def miscellaneous(accept, host, description):
+def dshield(accept, host, description):
     yield Test(
         accept=accept,
         description=description,
-        host=host,
+        host=host + ".dshield.org",
         port=443
+    )
+
+
+@testenv
+def tlsfun(accept, name, description, forced_result):
+    yield Test(
+        accept=accept,
+        description=description,
+        host=name + ".tlsfun.de",
+        port=443,
+        forced_result=forced_result
     )
 
 
@@ -233,7 +244,7 @@ def local(accept, cn, description):
 
 
 @testgroup
-def badssl_tests():
+def sni_tests():
     forced_result = None
 
     res = yield Test(
@@ -263,7 +274,8 @@ def badssl_tests():
         badssl(False, "incomplete-chain", "incomplete chain of trust", forced_result),
         badssl(False, "superfish", "Superfish CA", forced_result),
         badssl(False, "edellroot", "eDellRoot CA", forced_result),
-        badssl(False, "dsdtestprovider", "DSDTestProvider CA", forced_result)
+        badssl(False, "dsdtestprovider", "DSDTestProvider CA", forced_result),
+        tlsfun(False, "badcert-edell", "eDellRoot CA #2", forced_result)
     )
 
 
@@ -301,16 +313,15 @@ local_tests = testgroup(
     badssl_onlymyca("use only the given CA bundle, not system's")
 )
 
-miscellaneous_tests = testgroup(
-    miscellaneous(False, "sslv3.dshield.org", "protection against POODLE attack"),
-    miscellaneous(False, "badcert-edell.tlsfun.de", "eDellRoot CA #2")
+dshield_tests = testgroup(
+    dshield(False, "sslv3", "protection against POODLE attack")
 )
 
 all_tests = testgroup(
-    badtls_tests,
-    badssl_tests,
     ssllabs_tests,
     freakattack_tests,
-    miscellaneous_tests,
+    dshield_tests,
+    sni_tests,
+    badtls_tests,
     local_tests
 )


### PR DESCRIPTION
Fixed tlsfun.de sni requirement and decimated `miscellaneous`.
