### PR TITLE
edit java context printing

### DIFF
--- a/stubs/java-https/Run.java
+++ b/stubs/java-https/Run.java
@@ -26,7 +26,6 @@ public class Run{
 			con.getContent();
 			System.out.println("ACCEPT");
 		} catch (javax.net.ssl.SSLException e) {
-			System.out.println(e);
 			System.out.println("REJECT");
 		}
 

--- a/stubs/java-net/Run.java
+++ b/stubs/java-net/Run.java
@@ -23,7 +23,6 @@ public class Run {
       url.openConnection().getContent();
       System.out.println("ACCEPT");
     } catch (javax.net.ssl.SSLException e){
-      System.out.println(e);
       System.out.println("REJECT");
     }
     System.exit(0);


### PR DESCRIPTION
which one:
- [x] rm println(e)   //currently
  - why not: maybe debugging more time consuming? etc..
  - why: maybe clearer?
- [ ] edit println(e)
  - how?
- [ ] something else
