### PR TITLE
Make python2-urllib2 compatible with more Python 2.7 versions

### DIFF
--- a/stubs/python2-urllib2/run.py
+++ b/stubs/python2-urllib2/run.py
@@ -11,7 +11,7 @@ cafile = sys.argv[3] if len(sys.argv) > 3 else None
 
 try:
     urllib2.urlopen("https://" + host + ":" + port, cafile=cafile)
-except ssl.CertificateError:
+except getattr(ssl, "CertificateError", ()):
     print("REJECT")
 except urllib2.URLError as exc:
     if not isinstance(exc.reason, ssl.SSLError):

--- a/stubs/python2-urllib2/run.py
+++ b/stubs/python2-urllib2/run.py
@@ -9,8 +9,18 @@ host = sys.argv[1]
 port = sys.argv[2]
 cafile = sys.argv[3] if len(sys.argv) > 3 else None
 
+# Python 2.7.9 added the cafile argument support to urllib2.urlopen. Some
+# distributions have also backported the support to nominally earlier versions
+# so a basic version number check won't be sufficient.
+# As a workaround pass in the cafile argument only if needed, and prepare to
+# catch the TypeError if the used urllib2.urlopen doesn't support cafile yet.
+kwargs = {} if cafile is None else {"cafile": cafile}
 try:
-    urllib2.urlopen("https://" + host + ":" + port, cafile=cafile)
+    urllib2.urlopen("https://" + host + ":" + port, **kwargs)
+except TypeError:
+    if not kwargs:
+        raise
+    print "UNSUPPORTED"
 except getattr(ssl, "CertificateError", ()):
     print("REJECT")
 except urllib2.URLError as exc:


### PR DESCRIPTION
Try to `catch ssl.CertificateError:` only if `ssl.CertificateError` is defined. Otherwise bail out by effectively doing a dummy `catch ():`.

**Update:** Commit 261ba6478ca3c4027b81b418ba772ed458e26ef6 expands the fix by passing in the `cafile` argument only when needed, preparing to catch the `TypeError` if the used `urllib2.urlopen` doesn't support cafile yet.

Python 2.7.9 added the cafile argument support to `urllib2.urlopen`, but some distributions have also backported the support to nominally earlier versions so a basic version number check won't (probably) be sufficient. Another option (that is not included in this pull request) would be to use `inspect.getargspec` to examine the arguments `urlopen` accepts, something along these lines:

``` python
if "cafile" in inspect.getargspec(urllib2.urlopen).args:
    ...
```

In the end these changes accidentally (whoops!) make the stub compatible with all Python 2.6 & 2.7 versions.
