### PR TITLE
Treat any sys.platform starting with "linux" as Linux

### DIFF
--- a/runners/trytls/utils.py
+++ b/runners/trytls/utils.py
@@ -41,7 +41,7 @@ def platform_info():
     Return a human-readable name for the currently used platform.
     """
 
-    if sys.platform == "linux2":
+    if sys.platform.startswith("linux"):
         distname, version, _ = platform.linux_distribution()
         if not distname:
             return "Linux"


### PR DESCRIPTION
Since Python 3.3, sys.platform contains just `linux`. Previously it contained `linux2` or `linux3` depending on the Linux version used to build Python.
