### PR TITLE
Use "cryptography" package instead of the OpenSSL command line tool

### DIFF
--- a/runners/trytls/gencert.py
+++ b/runners/trytls/gencert.py
@@ -1,69 +1,81 @@
-import errno
-import subprocess
-from .utils import tmpfiles, memoized
+from __future__ import absolute_import, unicode_literals
+
+import uuid
+import datetime
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from .utils import memoized
 
 
-class OpenSSLNotFound(Exception):
-    pass
+def _pem_cert(cert):
+    return cert.public_bytes(serialization.Encoding.PEM)
 
 
-def openssl(args, input=None):
-    try:
-        process = subprocess.Popen(
-            ["openssl"] + list(args),
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        )
-    except OSError as ose:
-        if ose.errno == errno.ENOENT:
-            raise OpenSSLNotFound("openssl command not found in the search path")
-        raise
-
-    stdout, _ = process.communicate(input)
-    if process.returncode != 0:
-        raise RuntimeError()
-    return stdout
+def _pem_key(key):
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption()
+    )
 
 
-@memoized
-def _ca_key():
-    return openssl(["genrsa", "4096"])
+def _gen_key():
+    return rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=4096,
+        backend=default_backend()
+    )
+_ca_key = memoized(_gen_key)
+_cert_key = memoized(_gen_key)
 
 
-@memoized
-def _cert_key():
-    return openssl(["genrsa", "4096"])
+def _ca_cert(private_key):
+    subject = issuer = x509.Name([
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "My Company")
+    ])
 
-
-_EXT_FILE_DATA = b"""
-basicConstraints = CA:FALSE
-"""
+    return x509.CertificateBuilder().subject_name(
+        subject
+    ).issuer_name(
+        issuer
+    ).public_key(
+        private_key.public_key()
+    ).not_valid_before(
+        datetime.datetime.utcnow() - datetime.timedelta(days=356)
+    ).not_valid_after(
+        datetime.datetime.utcnow() + datetime.timedelta(days=356)
+    ).serial_number(
+        int(uuid.uuid4())
+    ).add_extension(
+        x509.BasicConstraints(True, None),
+        critical=True
+    ).sign(private_key, hashes.SHA256(), default_backend())
 
 
 def gencert(cn):
-    subj = "/CN=" + cn
     ca_key = _ca_key()
+    ca_cert = _ca_cert(ca_key)
+
     cert_key = _cert_key()
+    cert = x509.CertificateBuilder().subject_name(
+        x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, cn)
+        ])
+    ).issuer_name(
+        ca_cert.subject
+    ).public_key(
+        cert_key.public_key()
+    ).not_valid_before(
+        datetime.datetime.utcnow() - datetime.timedelta(days=356)
+    ).not_valid_after(
+        datetime.datetime.utcnow() + datetime.timedelta(days=356)
+    ).serial_number(
+        int(uuid.uuid4())
+    ).sign(ca_key, hashes.SHA256(), default_backend())
 
-    # Generate the CA
-    with tmpfiles(ca_key) as ca_keyfile:
-        ca_data = openssl(["req", "-new", "-key", ca_keyfile, "-x509", "-subj", "/O=Fake Certificate Authority"])
-
-    # Generate a certificate signing request
-    with tmpfiles(cert_key) as cert_keyfile:
-        cert_csr = openssl(["req", "-new", "-subj", subj, "-key", cert_keyfile])
-
-    # Sign the certificate with the CA
-    with tmpfiles(ca_key, ca_data, _EXT_FILE_DATA) as (ca_keyfile, ca_file, ext_file):
-        cert_data = openssl(
-            ["x509", "-req", "-extfile", ext_file, "-CA", ca_file, "-CAkey", ca_keyfile, "-set_serial", "01"],
-            input=cert_csr
-        )
-
-    return cert_data, cert_key, ca_data
-
-
-def openssl_version():
-    ver = openssl(["version", "-v"]).strip().decode("ascii", "replace")
-    return " ".join(ver.split()[:2])
+    return _pem_cert(cert), _pem_key(cert_key), _pem_cert(ca_cert)

--- a/runners/trytls/gencert.py
+++ b/runners/trytls/gencert.py
@@ -46,7 +46,7 @@ _cert_key = memoized(_gen_key)
 
 def _ca_cert(private_key):
     subject = issuer = x509.Name([
-        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "My Company")
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Fake Certificate Authority")
     ])
 
     return x509.CertificateBuilder().subject_name(

--- a/runners/trytls/main.py
+++ b/runners/trytls/main.py
@@ -1,0 +1,14 @@
+import sys
+from . import __version__
+
+_main = sys.modules.get("__main__", None)
+if _main is not None and not hasattr(_main, "__requires__"):
+    _main.__requires__ = "trytls==" + __version__
+
+import pkg_resources
+
+for name in tuple(sys.modules):
+    if name.split(".")[0] in ("pkg_resources", "setuptools"):
+        del sys.modules[name]
+
+from runner import main

--- a/runners/trytls/main.py
+++ b/runners/trytls/main.py
@@ -5,10 +5,10 @@ _main = sys.modules.get("__main__", None)
 if _main is not None and not hasattr(_main, "__requires__"):
     _main.__requires__ = "trytls==" + __version__
 
-import pkg_resources
+import pkg_resources  # noqa
 
 for name in tuple(sys.modules):
     if name.split(".")[0] in ("pkg_resources", "setuptools"):
         del sys.modules[name]
 
-from runner import main
+from .runner import main  # noqa

--- a/runners/trytls/runner.py
+++ b/runners/trytls/runner.py
@@ -7,7 +7,7 @@ import string
 import argparse
 import subprocess
 
-from . import __version__, gencert, utils, results, bundles, testenv, formatters
+from . import __version__, utils, results, bundles, testenv, formatters
 
 
 class Unsupported(Exception):
@@ -22,13 +22,12 @@ class UnexpectedOutput(Exception):
     pass
 
 
-def output_info(formatter, args, openssl_version, runner_name="trytls"):
+def output_info(formatter, args, runner_name="trytls"):
     formatter.write_platform(utils.platform_info())
-    formatter.write_runner("{runner} {version} ({python}, {openssl})".format(
+    formatter.write_runner("{runner} {version} ({python})".format(
         runner=runner_name,
         version=__version__,
-        python=utils.python_info(),
-        openssl=openssl_version
+        python=utils.python_info()
     ))
     formatter.write_stub(args)
 
@@ -136,12 +135,6 @@ def run(formatter, args, tests):
 
 
 def main():
-    try:
-        openssl_version = gencert.openssl_version()
-    except gencert.OpenSSLNotFound as err:
-        print("ERROR: {}".format(err), file=sys.stderr)
-        return 1
-
     parser = argparse.ArgumentParser(
         usage="%(prog)s bundle command [arg ...]"
     )
@@ -189,7 +182,7 @@ def main():
         parser.error("too few arguments, missing command")
 
     with create_formatter(sys.stdout) as formatter:
-        output_info(formatter, command, openssl_version=openssl_version)
+        output_info(formatter, command)
         if not run(formatter, command, bundle):
             # Return with a non-zero exit code if all tests were not successful. The
             # CPython interpreter exits with 1 when an unhandled exception occurs,

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         ]
     },
     install_requires=[
-        "colorama"
+        "colorama",
+        "cryptography"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     packages=find_packages("./runners"),
     entry_points={
         "console_scripts": [
-            "trytls=trytls.runner:main"
+            "trytls=trytls.main:main"
         ],
         "trytls.bundles": [
             "https=trytls.bundles.https:all_tests"


### PR DESCRIPTION
Generate localhost test certs with the [`cryptography`](https://cryptography.io/) package instead of using the OpenSSL command line tool. As a consequence the code no more prints the OpenSSL version and doesn't check if the OpenSSL tool is in the path.

~~Another tangential change: The localhost HTTPS server is now run in a separate thread instead of a separate process. This enables passing a customized `ssl.SSLContext` to `http_server`, which can be used in the future to implement e.g. SNI tests via `ssl.SSLContext#set_servername_callback`.~~ _Update: Moved the changes mentioned in this paragraph to #261._

Prior to merging the code needs to be tested at least on Windows, OSX and a common Linux distribution of choice. See the [list of platforms `cryptography` supports](https://cryptography.io/en/latest/installation/#supported-platforms). @oherrala might be interested to check out whether this version of `trytls` can still be run on OpenBSD.

Closes #198.
