### PR TITLE
add reason if UNSUPPORTED

### DIFF
--- a/runners/trytls/runner.py
+++ b/runners/trytls/runner.py
@@ -136,7 +136,9 @@ def collect(test, args):
     try:
         accept, details = run_stub(list(args), test.host, test.port, test.cafile)
     except Unsupported as us:
-        return results.Skip(details=us.args[0])
+        return results.Skip(
+            reason="the stub couldn't implement the requested behaviour (e.g. setting CA certificate bundle)",
+            details=us.args[0])
     except UnexpectedOutput as uo:
         output = uo.args[0].strip()
         if output:


### PR DESCRIPTION
If you think that the substring "(e.g. setting CA certificate bundle)" should be removed or the whole string otherwise modified somehow, please do propose alternatives.

closes #211 
