### PR TITLE
Fix typos

### DIFF
--- a/backends/badtls/README.md
+++ b/backends/badtls/README.md
@@ -11,7 +11,7 @@ with some reasoning for the selection.
 ```
 domain-match.badtls.io:10000      valid certificate Common Name, should pass
 wildcard-match.badtls.io:10001    valid certificate Common Name using wildcards, should pass
-san-match.badtls.io:10002         supprt for Subject Alternative Name (SAN), should pass
+san-match.badtls.io:10002         support for Subject Alternative Name (SAN), should pass
 dh1024.badtls.io:10005            TLS handshake with 1024 bit Diffie-Hellman (DH), should pass
 expired-1963.badtls.io:11000      certificate expired in year 1963, should fail
 future.badtls.io:11001            certificate validity starts in future, should fail

--- a/doc/workshop/presentation.md
+++ b/doc/workshop/presentation.md
@@ -110,5 +110,5 @@ chosen target language and library or service, e.g. `<language>-<library>`.
 
 A stub should have a top level `README.md` that describes how to run the stub.
 
-The stubs should have a `run` command with optional and approriate file
+The stubs should have a `run` command with optional and appropriate file
 extension for the language in question.

--- a/runners/bashtls/README.md
+++ b/runners/bashtls/README.md
@@ -8,8 +8,8 @@ $ bash init <stubspath> <"backend1 backed2 ... backend4"> \ 	#the spaces are of 
 	<language>[:stub1:stub2:...:stubN][&driver1&driver2&driver3]
 
  * language = used language when running stubs
- * stub1 .. stubN = optional arguments, if not given all stubs will be ran
- * driver1 .. driverN = optional arguments, if not gived all drivers will be used
+ * stub1 .. stubN = optional arguments; if not given, all stubs will be run
+ * driver1 .. driverN = optional arguments; if not given, all drivers will be used
 ```
 
 ## HOX
@@ -22,7 +22,7 @@ $ bash init <stubspath> <"backend1 backed2 ... backend4"> \ 	#the spaces are of 
 
 ```
 $ bash init ../../stubs "badssl-all" "python3"
-	* run all python3 drivers using all python3 stubs agains all(that are in conf-file) badssl servers
+	* run all python3 drivers using all python3 stubs against all (that are in conf-file) badssl servers
 
 $ bash init ../../stubs "badssl-all" "python3:python3-urllib&python3_1" "bash"
 	* run python3(language) python3-urllib(stub) using python3_1(driver) and all bash stubs using all bash drivers

--- a/runners/bashtls/shared/simplerunner/README.md
+++ b/runners/bashtls/shared/simplerunner/README.md
@@ -1,7 +1,7 @@
 ##Info
 
 This is to be a part of the maybe to be runner.
-This can also be ran itself.
+This can also be run itself.
 
 #Get started
 
@@ -107,7 +107,7 @@ $ bash run mono '../trytls/stubs/cSharp-Net/run.exe' 'conf/badssl-all' _ _ CShar
 ...
 ```
 
-agains trytls backend
+against trytls backend
 ```console
 $ bash run python3 '../trytls/stubs/python3-urllib/run.py' '../trytls/backends/trytls/tmp/conf' ../trytls/backends/trytls/tmp/certs
 

--- a/runners/trytls/README.md
+++ b/runners/trytls/README.md
@@ -25,7 +25,7 @@ Valid bundle options:
   https
 ```
 
-For example, when testing a HTTP(S) library you'd want to use the `https` bundle. That specific bundle knows to answer to the library's requests with proper HTTP responses, making testing easier.
+For example, when testing an HTTP(S) library you'd want to use the `https` bundle. That specific bundle knows to answer to the library's requests with proper HTTP responses, making testing easier.
 
 The parameters following the bundle are `COMMAND` and 0-n `ARG` arguments for the command. These describe how the *stub* - a piece of code for testing some library - should be launched. The [`stubs/`](../stubs) directory in this repository contains multiple example stubs. As an example the included stub for testing Python's `urllib2` library can be run with:
 
@@ -71,4 +71,4 @@ writefile("cert.pem", cert)
 writefile("cert.key", key)
 writefile("ca.pem", ca)
 ```
-Now launching a HTTP server on localhost with the `cert.pem` and `cert.key` files allows clients to create a verified connection to it using the `ca.pem` CA file.
+Now launching an HTTP server on localhost with the `cert.pem` and `cert.key` files allows clients to create a verified connection to it using the `ca.pem` CA file.

--- a/runners/trytls/bundles/https.py
+++ b/runners/trytls/bundles/https.py
@@ -231,7 +231,7 @@ def tlsfun_tests():
         forced_result=forced_result
     )
     if res.type != results.Pass and not forced_result:
-        forced_result = results.Skip("stub didn't reject a expired + self-signed certificate")
+        forced_result = results.Skip("stub didn't reject an expired + self-signed certificate")
 
     yield testgroup(
         tlsfun(False, "badcert-edell", "eDellRoot CA #2", forced_result),

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import imp
 import sys
 from setuptools import setup, find_packages
 
-# Check the the Python version
+# Check the Python version
 if sys.version_info < (3,):
     py_required = (2, 7, 9)
 else:

--- a/stubs/README.md
+++ b/stubs/README.md
@@ -21,7 +21,7 @@ line arguments (`<host> <port> [ca-bundle]`):
    file to be used. The bundle file should consists of PEM encoded
    certificates concatenated together.
 
-Depending on the TLS library used in a stub, the library might use it's own
+Depending on the TLS library used in a stub, the library might use its own
 CA certificate bundle or one delivered by the operating system or one delivered
 by the stub.
 
@@ -53,7 +53,7 @@ The data printed should follow the following set of instructions or a similar on
           return zero
    4.2  else (the stub could not connect due to reasons unrelated to TLS/SSL (Name resolution, etc..))
           goto "fatal error" (5.0, see one line below for more info)
-5.0 else ("fatal error occured")
+5.0 else ("fatal error occurred")
       (optional error message)
       return value other than zero
 </pre>
@@ -110,13 +110,13 @@ A stub should be confined to a directory named in a way that describes the
 chosen target language and library or service, e.g. `<language>-<library>`.
 
 A stub should have a top level `README.md` which describes how to run the stub and
-how to install the potential dependancies needed.
+how to install the potential dependencies needed.
 
-The stubs should have a `run` command with optional and approriate file
+The stubs should have a `run` command with optional and appropriate file
 extension for the language in question.
 
 Optionally a stub can have a `Dockerfile` that encapsulates the environment
-and the dependancies needed to run the example.
+and the dependencies needed to run the example.
 
 Ideally, one should also include a `results.md` that contains the result of a test run as follows:
 

--- a/stubs/go-nethttp/run.go
+++ b/stubs/go-nethttp/run.go
@@ -18,7 +18,7 @@ func main() {
 
 	url := "https://" + os.Args[1] + ":" + os.Args[2]
 
-	// Perform a HTTP(s) Request
+	// Perform an HTTP(S) Request
 	_, err := http.Get(url)
 	if err != nil {
 		fatalError := strings.Contains(err.Error(), "no such host")


### PR DESCRIPTION
Found mostly using [mwic](http://jwilk.net/software/mwic) and [anorack](https://github.com/jwilk/anorack).
