### PR TITLE
Use "oscrypto" & "certbuilder" packages instead of the OpenSSL command line tool 

### DIFF
--- a/runners/trytls/runner.py
+++ b/runners/trytls/runner.py
@@ -7,7 +7,7 @@ import string
 import argparse
 import subprocess
 
-from . import __version__, gencert, utils, results, bundles, testenv, formatters
+from . import __version__, utils, results, bundles, testenv, formatters
 
 
 class Unsupported(Exception):
@@ -22,13 +22,12 @@ class UnexpectedOutput(Exception):
     pass
 
 
-def output_info(formatter, args, openssl_version, runner_name="trytls"):
+def output_info(formatter, args, runner_name="trytls"):
     formatter.write_platform(utils.platform_info())
-    formatter.write_runner("{runner} {version} ({python}, {openssl})".format(
+    formatter.write_runner("{runner} {version} ({python})".format(
         runner=runner_name,
         version=__version__,
-        python=utils.python_info(),
-        openssl=openssl_version
+        python=utils.python_info()
     ))
     formatter.write_stub(args)
 
@@ -136,12 +135,6 @@ def run(formatter, args, tests):
 
 
 def main():
-    try:
-        openssl_version = gencert.openssl_version()
-    except gencert.OpenSSLNotFound as err:
-        print("ERROR: {}".format(err), file=sys.stderr)
-        return 1
-
     parser = argparse.ArgumentParser(
         usage="%(prog)s bundle command [arg ...]"
     )
@@ -189,7 +182,7 @@ def main():
         parser.error("too few arguments, missing command")
 
     with create_formatter(sys.stdout) as formatter:
-        output_info(formatter, command, openssl_version=openssl_version)
+        output_info(formatter, command)
         if not run(formatter, command, bundle):
             # Return with a non-zero exit code if all tests were not successful. The
             # CPython interpreter exits with 1 when an unhandled exception occurs,

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ setup(
         ]
     },
     install_requires=[
-        "colorama"
+        "colorama",
+        "oscrypto",
+        "certbuilder"
     ]
 )


### PR DESCRIPTION
Generate localhost test certs with the [`oscrypto`](https://github.com/wbond/oscrypto) and [`certbuilder`](https://github.com/wbond/certbuilder) packages instead of using the OpenSSL command line tool. As a consequence the code no more prints the OpenSSL version and doesn't check if the OpenSSL tool is in the path.

Prior to merging the code needs to be tested at least on Windows, OSX and a common Linux distribution of choice. See the [list of platforms `oscrypto` supports](https://github.com/wbond/oscrypto#supported-operating-systems). @oherrala might be interested to check out whether this version of trytls can still be run on OpenBSD.

This is an alternative for #254. Closes #198.
