### PR TITLE
Edit run.go

### DIFF
--- a/stubs/go-nethttp/run.go
+++ b/stubs/go-nethttp/run.go
@@ -18,10 +18,10 @@ func main() {
 
 	url := "https://" + os.Args[1] + ":" + os.Args[2]
 
-	// Perform an HTTP(S) Request
+	// Perform an HTTPS Request
 	_, err := http.Get(url)
 	if err != nil {
-		fatalError := strings.Contains(err.Error(), "no such host")
+		fatalError := strings.Contains(err.Error(), "dial tcp")
 		fmt.Println(err.Error())
 		if fatalError {
 			os.Exit(1)


### PR DESCRIPTION
## Solution 1 (current)

**catch 'fatal' (unrelated to TLS) errors**
-> Some of the errors unrelated to TLS may cause the stub to print REJECT even though 'are not supposed to'
## Solution 2 (original)

**catch 'all the' TLS related Errors**
-> some of the TLS related errors many not get to print REJECT as they are supposed to.
## Something else

Yes there are other solutions as well
