### PR TITLE
JSON output for the trytls tool

### DIFF
--- a/runners/trytls/formatters/__init__.py
+++ b/runners/trytls/formatters/__init__.py
@@ -1,0 +1,12 @@
+import pkg_resources
+
+
+def iter_formatters():
+    for entry in pkg_resources.iter_entry_points("trytls.formatters"):
+        yield entry.name
+
+
+def load_formatter(name):
+    for entry in pkg_resources.iter_entry_points("trytls.formatters", name):
+        return entry.load()
+    return None

--- a/runners/trytls/formatters/__init__.py
+++ b/runners/trytls/formatters/__init__.py
@@ -10,15 +10,3 @@ def load_formatter(name):
     for entry in pkg_resources.iter_entry_points("trytls.formatters", name):
         return entry.load()
     return None
-
-
-def _indent(text, by=4, first_line=True):
-    r"""
-    >>> indent("a\nb\nc", by=1) == ' a\n b\n c'
-    True
-    """
-
-    spaces = " " * by
-    lines = text.splitlines(True)
-    prefix = lines.pop(0) if (lines and not first_line) else ""
-    return prefix + "".join(spaces + line for line in lines)

--- a/runners/trytls/formatters/__init__.py
+++ b/runners/trytls/formatters/__init__.py
@@ -10,3 +10,15 @@ def load_formatter(name):
     for entry in pkg_resources.iter_entry_points("trytls.formatters", name):
         return entry.load()
     return None
+
+
+def _indent(text, by=4, first_line=True):
+    r"""
+    >>> indent("a\nb\nc", by=1) == ' a\n b\n c'
+    True
+    """
+
+    spaces = " " * by
+    lines = text.splitlines(True)
+    prefix = lines.pop(0) if (lines and not first_line) else ""
+    return prefix + "".join(spaces + line for line in lines)

--- a/runners/trytls/formatters/_utils.py
+++ b/runners/trytls/formatters/_utils.py
@@ -1,0 +1,10 @@
+def indent(text, by=4, first_line=True):
+    r"""
+    >>> indent("a\nb\nc", by=1) == ' a\n b\n c'
+    True
+    """
+
+    spaces = " " * by
+    lines = text.splitlines(True)
+    prefix = lines.pop(0) if (lines and not first_line) else ""
+    return prefix + "".join(spaces + line for line in lines)

--- a/runners/trytls/formatters/default.py
+++ b/runners/trytls/formatters/default.py
@@ -5,7 +5,7 @@ import contextlib
 from colorama import Fore, Back, Style, init, AnsiToWin32
 
 from .. import utils, results
-from . import _indent
+from ._utils import indent
 
 
 @contextlib.contextmanager
@@ -73,14 +73,14 @@ class Format(object):
         reason = res.reason.rstrip()
         if reason:
             result += self._colorize("{RESET}{Formatter.base}\n")
-            result += _indent("reason: ", by=6)
-            result += _indent(self._colorize("{Formatter.reason}{}", reason), by=14, first_line=False)
+            result += indent("reason: ", by=6)
+            result += indent(self._colorize("{Formatter.reason}{}", reason), by=14, first_line=False)
 
         details = res.details.rstrip()
         if details:
             result += self._colorize("{RESET}{Formatter.base}\n")
-            result += _indent("output: ", by=6)
-            result += _indent(self._colorize("{Formatter.details}{}", details), by=14, first_line=False)
+            result += indent("output: ", by=6)
+            result += indent(self._colorize("{Formatter.details}{}", details), by=14, first_line=False)
 
         return result
 

--- a/runners/trytls/formatters/default.py
+++ b/runners/trytls/formatters/default.py
@@ -5,6 +5,7 @@ import contextlib
 from colorama import Fore, Back, Style, init, AnsiToWin32
 
 from .. import utils, results
+from . import _indent
 
 
 @contextlib.contextmanager
@@ -42,18 +43,6 @@ class DefaultFormatter(object):
         self._write(formatter.format(test, result))
 
 
-def indent(text, by=4, first_line=True):
-    r"""
-    >>> indent("a\nb\nc", by=1) == ' a\n b\n c'
-    True
-    """
-
-    spaces = " " * by
-    lines = text.splitlines(True)
-    prefix = lines.pop(0) if (lines and not first_line) else ""
-    return prefix + "".join(spaces + line for line in lines)
-
-
 def colorize(format_string, *args, **kwargs):
     keys = dict(Fore=Fore, Back=Back, Style=Style, RESET=Style.RESET_ALL)
     keys.update(kwargs)
@@ -84,14 +73,14 @@ class Format(object):
         reason = res.reason.rstrip()
         if reason:
             result += self._colorize("{RESET}{Formatter.base}\n")
-            result += indent("reason: ", by=6)
-            result += indent(self._colorize("{Formatter.reason}{}", reason), by=14, first_line=False)
+            result += _indent("reason: ", by=6)
+            result += _indent(self._colorize("{Formatter.reason}{}", reason), by=14, first_line=False)
 
         details = res.details.rstrip()
         if details:
             result += self._colorize("{RESET}{Formatter.base}\n")
-            result += indent("output: ", by=6)
-            result += indent(self._colorize("{Formatter.details}{}", details), by=14, first_line=False)
+            result += _indent("output: ", by=6)
+            result += _indent(self._colorize("{Formatter.details}{}", details), by=14, first_line=False)
 
         return result
 

--- a/runners/trytls/formatters/default.py
+++ b/runners/trytls/formatters/default.py
@@ -1,0 +1,117 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+import sys
+import contextlib
+from colorama import Fore, Back, Style, init, AnsiToWin32
+
+from .. import utils, results
+
+
+@contextlib.contextmanager
+def formatter(stream):
+    yield DefaultFormatter(stream)
+
+
+class DefaultFormatter(object):
+    def __init__(self, stream):
+        # Initialize colorama without wrapping sys.stdout globally
+        init(wrap=False)
+        self._stream = AnsiToWin32(sys.stdout, autoreset=True).stream
+
+    def _write(self, *strings):
+        for s in strings:
+            print(s, file=self._stream)
+
+    def write_platform(self, platform):
+        self._write(colorize("{Style.BRIGHT}platform:{RESET} {}", platform))
+
+    def write_runner(self, runner):
+        self._write(colorize("{Style.BRIGHT}runner:{RESET} {}", runner))
+
+    def write_stub(self, args):
+        self._write(colorize("{Style.BRIGHT}stub:{RESET} {}", utils.format_command(args)))
+
+    @contextlib.contextmanager
+    def tests(self):
+        yield self
+
+    def write_test(self, test, result):
+        formatter = formats.get(result.type)
+        if formatter is None:
+            raise RuntimeError("unknown result type")
+        self._write(formatter.format(test, result))
+
+
+def indent(text, by=4, first_line=True):
+    r"""
+    >>> indent("a\nb\nc", by=1) == ' a\n b\n c'
+    True
+    """
+
+    spaces = " " * by
+    lines = text.splitlines(True)
+    prefix = lines.pop(0) if (lines and not first_line) else ""
+    return prefix + "".join(spaces + line for line in lines)
+
+
+def colorize(format_string, *args, **kwargs):
+    keys = dict(Fore=Fore, Back=Back, Style=Style, RESET=Style.RESET_ALL)
+    keys.update(kwargs)
+    return format_string.format(*args, **keys)
+
+
+class Format(object):
+    def __init__(self, base="", type="", reason="", details=""):
+        self.base = base
+        self.type = type
+        self.reason = reason
+        self.details = details
+
+    def _colorize(self, format_string, *args, **kwargs):
+        keys = dict(Formatter=self)
+        keys.update(**kwargs)
+        return colorize(format_string, *args, **keys)
+
+    def format(self, test, res):
+        result = self._colorize(
+            "{Formatter.base}{Formatter.type}{result:>5}{RESET}{Formatter.base} {description} {Style.DIM}[{accept} {name}]",
+            result=res.name,
+            description=test.description,
+            accept="accept" if test.accept else "reject",
+            name=test.name
+        )
+
+        reason = res.reason.rstrip()
+        if reason:
+            result += self._colorize("{RESET}{Formatter.base}\n")
+            result += indent("reason: ", by=6)
+            result += indent(self._colorize("{Formatter.reason}{}", reason), by=14, first_line=False)
+
+        details = res.details.rstrip()
+        if details:
+            result += self._colorize("{RESET}{Formatter.base}\n")
+            result += indent("output: ", by=6)
+            result += indent(self._colorize("{Formatter.details}{}", details), by=14, first_line=False)
+
+        return result
+
+
+formats = {
+    results.Skip: Format(
+        base=Style.DIM
+    ),
+    results.Error: Format(
+        base=Fore.RED,
+        type=Back.RED + Fore.WHITE,
+        details=Style.DIM
+    ),
+    results.Fail: Format(
+        base=Fore.RED,
+        reason=Fore.RED + Style.DIM
+    ),
+    results.Pass: Format(
+        type=Fore.GREEN,
+        reason=Style.DIM,
+        details=Style.DIM
+    )
+}

--- a/runners/trytls/formatters/json.py
+++ b/runners/trytls/formatters/json.py
@@ -49,11 +49,19 @@ class JSONFormatter(object):
         if self._open:
             self._stream.write(",\n")
             self._stream.flush()
+
         obj = {
             "result": result.name,
             "description": test.description,
             "target": "{} {}".format("accept" if test.accept else "reject", test.name),
         }
+        reason = result.reason.rstrip()
+        if reason:
+            obj["reason"] = reason
+        details = result.details.rstrip()
+        if details:
+            obj["details"] = details
+
         self._stream.write(indent(json.dumps(obj, indent=4), 8))
         self._stream.flush()
         self._open = True

--- a/runners/trytls/formatters/json.py
+++ b/runners/trytls/formatters/json.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import json
 import contextlib
 
-from . import _indent
+from ._utils import indent
 
 
 @contextlib.contextmanager
@@ -54,6 +54,6 @@ class JSONFormatter(object):
             "description": test.description,
             "target": "{} {}".format("accept" if test.accept else "reject", test.name),
         }
-        self._stream.write(_indent(json.dumps(obj, indent=4), 8))
+        self._stream.write(indent(json.dumps(obj, indent=4), 8))
         self._stream.flush()
         self._open = True

--- a/runners/trytls/formatters/json.py
+++ b/runners/trytls/formatters/json.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+import json
+import contextlib
+
+from . import _indent
+
+
+@contextlib.contextmanager
+def formatter(stream):
+    stream.write("{\n")
+    yield JSONFormatter(stream)
+    stream.write("\n}\n")
+    stream.flush()
+
+
+class JSONFormatter(object):
+    def __init__(self, stream):
+        self._stream = stream
+        self._open = False
+
+    def _open_property(self, name):
+        if self._open:
+            self._stream.write(",\n")
+        self._stream.write("    " + json.dumps(name) + ": ")
+        self._open = True
+
+    def _write_property(self, name, value):
+        self._open_property(name)
+        self._stream.write(json.dumps(value))
+
+    def write_platform(self, platform):
+        self._write_property("platform", platform)
+
+    def write_runner(self, runner):
+        self._write_property("runner", runner)
+
+    def write_stub(self, args):
+        self._write_property("stub", args)
+
+    @contextlib.contextmanager
+    def tests(self):
+        self._open_property("tests")
+        self._stream.write("[\n")
+        yield JSONFormatter(self._stream)
+        self._stream.write("\n    ]")
+
+    def write_test(self, test, result):
+        if self._open:
+            self._stream.write(",\n")
+            self._stream.flush()
+        obj = {
+            "result": result.name,
+            "description": test.description,
+            "target": "{} {}".format("accept" if test.accept else "reject", test.name),
+        }
+        self._stream.write(_indent(json.dumps(obj, indent=4), 8))
+        self._stream.flush()
+        self._open = True

--- a/runners/trytls/runner.py
+++ b/runners/trytls/runner.py
@@ -6,25 +6,9 @@ import sys
 import string
 import argparse
 import subprocess
-from colorama import Fore, Back, Style, init, AnsiToWin32
 
+from .formatters.default import formatter as default_formatter
 from . import __version__, gencert, utils, results, bundles, testenv
-
-
-# Initialize colorama without wrapping sys.stdout globally
-init(wrap=False)
-wrapped_stdout = AnsiToWin32(sys.stdout, autoreset=True).stream
-
-
-def colorize(format_string, *args, **kwargs):
-    keys = dict(Fore=Fore, Back=Back, Style=Style, RESET=Style.RESET_ALL)
-    keys.update(kwargs)
-    return format_string.format(*args, **keys)
-
-
-def write(*strings):
-    for s in strings:
-        print(s, file=wrapped_stdout)
 
 
 class Unsupported(Exception):
@@ -39,36 +23,15 @@ class UnexpectedOutput(Exception):
     pass
 
 
-def indent(text, by=4, first_line=True):
-    r"""
-    >>> indent("a\nb\nc", by=1) == ' a\n b\n c'
-    True
-    """
-
-    spaces = " " * by
-    lines = text.splitlines(True)
-    prefix = lines.pop(0) if (lines and not first_line) else ""
-    return prefix + "".join(spaces + line for line in lines)
-
-
-def output_info(args, openssl_version, runner_name="trytls"):
-    write(
-        colorize(
-            "{Style.BRIGHT}platform:{RESET} {platform}",
-            platform=utils.platform_info()
-        ),
-        colorize(
-            "{Style.BRIGHT}runner:{RESET} {runner} {version} ({python}, {openssl})",
-            runner=runner_name,
-            version=__version__,
-            python=utils.python_info(),
-            openssl=openssl_version
-        ),
-        colorize(
-            "{Style.BRIGHT}stub:{RESET} {command}",
-            command=utils.format_command(args)
-        )
-    )
+def output_info(formatter, args, openssl_version, runner_name="trytls"):
+    formatter.write_platform(utils.platform_info())
+    formatter.write_runner("{runner} {version} ({python}, {openssl})".format(
+        runner=runner_name,
+        version=__version__,
+        python=utils.python_info(),
+        openssl=openssl_version
+    ))
+    formatter.write_stub(args)
 
 
 # A regex that matches to any byte that is not a 7-bit ASCII printable.
@@ -157,81 +120,18 @@ def collect(test, args):
         return results.Fail(details=details)
 
 
-class Formatter(object):
-    def __init__(self, base="", type="", reason="", details=""):
-        self.base = base
-        self.type = type
-        self.reason = reason
-        self.details = details
-
-    def _colorize(self, format_string, *args, **kwargs):
-        keys = dict(Formatter=self)
-        keys.update(**kwargs)
-        return colorize(format_string, *args, **keys)
-
-    def format(self, test, res):
-        result = self._colorize(
-            "{Formatter.base}{Formatter.type}{result:>5}{RESET}{Formatter.base} {description} {Style.DIM}[{accept} {name}]",
-            result=res.name,
-            description=test.description,
-            accept="accept" if test.accept else "reject",
-            name=test.name
-        )
-
-        reason = res.reason.rstrip()
-        if reason:
-            result += self._colorize("{RESET}{Formatter.base}\n")
-            result += indent("reason: ", by=6)
-            result += indent(self._colorize("{Formatter.reason}{}", reason), by=14, first_line=False)
-
-        details = res.details.rstrip()
-        if details:
-            result += self._colorize("{RESET}{Formatter.base}\n")
-            result += indent("output: ", by=6)
-            result += indent(self._colorize("{Formatter.details}{}", details), by=14, first_line=False)
-
-        return result
-
-
-formats = {
-    results.Skip: Formatter(
-        base=Style.DIM
-    ),
-    results.Error: Formatter(
-        base=Fore.RED,
-        type=Back.RED + Fore.WHITE,
-        details=Style.DIM
-    ),
-    results.Fail: Formatter(
-        base=Fore.RED,
-        reason=Fore.RED + Style.DIM
-    ),
-    results.Pass: Formatter(
-        type=Fore.GREEN,
-        reason=Style.DIM,
-        details=Style.DIM
-    )
-}
-
-
-def format_result(test, res):
-    formatter = formats.get(res.type)
-    if formatter is None:
-        raise RuntimeError("unknown result type")
-    return formatter.format(test, res)
-
-
-def run(args, tests):
+def run(formatter, args, tests):
     fail_count = 0
     error_count = 0
 
-    for test, res in testenv.run(tests, collect, args):
-        write(format_result(test, res))
+    with formatter.tests() as writer:
+        for test, result in testenv.run(tests, collect, args):
+            writer.write_test(test, result)
 
-        if res.type == results.Fail:
-            fail_count += 1
-        elif res.type == results.Error:
-            error_count += 1
+            if result.type == results.Fail:
+                fail_count += 1
+            elif result.type == results.Error:
+                error_count += 1
 
     return fail_count == 0 and error_count == 0
 
@@ -240,7 +140,7 @@ def main():
     try:
         openssl_version = gencert.openssl_version()
     except gencert.OpenSSLNotFound as err:
-        write(colorize("{Back.RED}{Fore.WHITE}ERROR:{RESET} {}", err))
+        print("ERROR: {}".format(err), file=sys.stderr)
         return 1
 
     parser = argparse.ArgumentParser(
@@ -264,7 +164,8 @@ def main():
 
     if bundle_name is None:
         bundle_list = sorted(bundles.iter_bundles())
-        parser.error("missing the bundle argument\n\nValid bundle options:\n" + indent("\n".join(bundle_list), 2))
+        bundle_lines = ["  " + x for x in bundle_list]
+        parser.error("missing the bundle argument\n\nValid bundle options:\n" + "\n".join(bundle_lines))
 
     bundle = bundles.load_bundle(bundle_name)
     if bundle is None:
@@ -273,14 +174,15 @@ def main():
     if not command:
         parser.error("too few arguments, missing command")
 
-    output_info(command, openssl_version=openssl_version)
-    if not run(command, bundle):
-        # Return with a non-zero exit code if all tests were not successful. The
-        # CPython interpreter exits with 1 when an unhandled exception occurs,
-        # and with 2 when there is a problem with a command line parameter. The
-        # argparse module also uses the code 2 for the same purpose. Therefore
-        # the chosen return value here is 3.
-        return 3
+    with default_formatter(sys.stdout) as formatter:
+        output_info(formatter, command, openssl_version=openssl_version)
+        if not run(formatter, command, bundle):
+            # Return with a non-zero exit code if all tests were not successful. The
+            # CPython interpreter exits with 1 when an unhandled exception occurs,
+            # and with 2 when there is a problem with a command line parameter. The
+            # argparse module also uses the code 2 for the same purpose. Therefore
+            # the chosen return value here is 3.
+            return 3
     return 0
 
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(
             "https=trytls.bundles.https:all_tests"
         ],
         "trytls.formatters": [
-            "default=trytls.formatters.default:formatter"
+            "default=trytls.formatters.default:formatter",
+            "json=trytls.formatters.json:formatter"
         ]
     },
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ setup(
         ],
         "trytls.bundles": [
             "https=trytls.bundles.https:all_tests"
+        ],
+        "trytls.formatters": [
+            "default=trytls.formatters.default:formatter"
         ]
     },
     install_requires=[


### PR DESCRIPTION
This pull request adds the command line option `--formatter` to the `trytls` tool, and adds a new formatting option `json`:

``` sh
$ trytls https --formatter=json python stubs/python2-urllib2/run.py 
{
    "platform": "OS X 10.11.6",
    "runner": "trytls 0.3.4 (CPython 2.7.12, OpenSSL 0.9.8zh)",
    "stub": ["python", "stubs/python2-urllib2/run.py"],
    "tests": [
        {
            "target": "reject www.ssllabs.com:10443", 
            "result": "PASS", 
            "description": "protect against Apple's TLS vulnerability CVE-2014-1266"
        },
        {
            "target": "reject www.ssllabs.com:10444", 
            "result": "PASS", 
            "description": "protect against the FREAK attack"
        },
        ...
    ]
}
```

The option has to be given between the bundle name and the stub command. The default value for `--formatter` is `default` that loads up the regular old output style. Therefore running the following command is the same thing as running the same command _without_ the `--formatter` parameter:

``` sh
$ trytls https --formatter=default python stubs/python2-urllib2/run.py 
```

The formatter names are registered as `setuptools` entry points in `setup.py`, and their not-too-pretty implementations can be found from `trytls.formatters`.

Closes #96.
