### PR TITLE
Remove double dashes from documentation

### DIFF
--- a/doc/workshop/presentation.md
+++ b/doc/workshop/presentation.md
@@ -37,7 +37,7 @@ In case you don't have `pip` (https://pip.pypa.io/) installed, please refer to t
 Run a stub yourself:
 
 ```
-$ trytls https -- python stubs/python-urllib2/run.py
+$ trytls https python stubs/python-urllib2/run.py
   PASS badssl(False, 'expired')
   PASS badssl(False, 'wrong.host')
   PASS badssl(False, 'self-signed')
@@ -99,7 +99,7 @@ Unless a fatal error occurs, examples should always return with process exit val
 If you need a quick recap of the calling convention,
 go to `stubs/` folder in our GitHub repo https://github.com/ouspg/trytls.git
 
-$ trytls https -- python stubs/python-urllib2/run.py
+$ trytls https python stubs/python-urllib2/run.py
 
 ---
 

--- a/runners/trytls/README.md
+++ b/runners/trytls/README.md
@@ -3,7 +3,7 @@
 ## Quick Start
 
 ```
-$ trytls https -- python stubs/python-urllib2/run.py
+$ trytls https python stubs/python-urllib2/run.py
 ```
 
 ## Detailed Usage
@@ -11,14 +11,14 @@ $ trytls https -- python stubs/python-urllib2/run.py
 The `trytls` tool is a *runner*, meant for testing how well different libraries implement their TLS certificate verification. This is done by feeding the libraries collections of pre-canned certificates and observing their output. The basic usage pattern of the tool is the following:
 
 ```
-trytls BUNDLE -- COMMAND [ARG ...]
+trytls BUNDLE COMMAND [ARG ...]
 ```
 
 The first command line parameter `BUNDLE` is used to tell which test *bundle* should be run. A bundle is a collection of TLS tests specialized for some protocol/situation. Launching the runner without any arguments lists the available bundles:
 
 ```
 $ trytls
-usage: trytls BUNDLE -- COMMAND [ARG ...]
+usage: trytls BUNDLE COMMAND [ARG ...]
 trytls: error: missing the bundle argument
 
 Valid bundle options:
@@ -30,7 +30,7 @@ For example, when testing an HTTP(S) library you'd want to use the `https` bundl
 The parameters following the bundle are `COMMAND` and 0-n `ARG` arguments for the command. These describe how the *stub* - a piece of code for testing some library - should be launched. The [`stubs/`](../stubs) directory in this repository contains multiple example stubs. As an example the included stub for testing Python's `urllib2` library can be run with:
 
 ```
-$ trytls https -- python stubs/python-urllib2/run.py
+$ trytls https python stubs/python-urllib2/run.py
   PASS badssl(False, 'expired')
   PASS badssl(False, 'wrong.host')
   ...


### PR DESCRIPTION
Double dashes has been optional since #119 got merged.
