### PR TITLE
Refactor to more idiomatic go

### DIFF
--- a/stubs/go-nethttp/run.go
+++ b/stubs/go-nethttp/run.go
@@ -51,9 +51,11 @@ func checkTLS(host, port, caFileName string) error {
 	uri := "https://" + net.JoinHostPort(host, port)
 	if _, err := client.Get(uri); err != nil {
 		if urlerr, ok := err.(*url.Error); ok {
-			if _, ok := urlerr.Err.(*net.OpError); ok {
-				// Connection errors are fatal without verdict
-				return err
+			if operr, ok := urlerr.Err.(*net.OpError); ok {
+				if operr.Op == "dial" {
+					// Connection errors are fatal without verdict
+					return err
+				}
 			}
 		}
 		fmt.Println(err.Error())

--- a/stubs/go-nethttp/run.go
+++ b/stubs/go-nethttp/run.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -13,15 +14,18 @@ import (
 	"time"
 )
 
+var timeout = flag.Duration("timeout", 5*time.Second, "HTTP request timeout (ms)")
+
 func main() {
+	flag.Parse()
 	var host, port, caFileName string
-	switch len(os.Args) {
-	case 4:
-		caFileName = os.Args[3]
-		fallthrough
+	switch len(flag.Args()) {
 	case 3:
-		host = os.Args[1]
-		port = os.Args[2]
+		caFileName = flag.Arg(2)
+		fallthrough
+	case 2:
+		host = flag.Arg(0)
+		port = flag.Arg(1)
 	default:
 		fmt.Printf("usage: %v <host> <port> [cafile]\n", os.Args[0])
 		os.Exit(1)
@@ -35,7 +39,7 @@ func main() {
 
 func checkTLS(host, port, caFileName string) error {
 	client := &http.Client{
-		Timeout: 5 * time.Second,
+		Timeout: *timeout,
 	}
 
 	if caFileName != "" {


### PR DESCRIPTION
- Support IPv6 literal addresses
- Set 5 second timeout
- Use type assertion instead of string match for detecting connection errors

Hopefully more readable and idiomatic code now.
