### PR TITLE
Enable AppVeyor for tests on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TryTLS [![CircleCI](https://circleci.com/gh/ouspg/trytls.svg?style=shield)](https://circleci.com/gh/ouspg/trytls)
+# TryTLS [![CircleCI](https://circleci.com/gh/ouspg/trytls.svg?style=shield)](https://circleci.com/gh/ouspg/trytls) [![Build status](https://ci.appveyor.com/api/projects/status/91p39fn87pbiy1gs?svg=true)](https://ci.appveyor.com/project/jviide/trytls)
 
 Does *your* TLS/SSL library check
 [certificates](https://tools.ietf.org/html/rfc5280) properly?

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,8 @@
+build: off
+deploy: off
+
+install:
+  - pip install tox
+
+test_script:
+  - python -m tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ build: off
 deploy: off
 
 install:
-  - pip install tox
+  - python -m pip install tox
 
 test_script:
   - python -m tox


### PR DESCRIPTION
Currently the tests don't pass thanks to missing `openssl`.
