### PR TITLE
Add subjectAltNames to localhost tests (fixes #222)

### DIFF
--- a/runners/trytls/gencert.py
+++ b/runners/trytls/gencert.py
@@ -57,17 +57,18 @@ def _gen_ca():
     )
 
 
-def gencert(cn):
+def gencert(name):
     ca_cert_data, ca_private_data = _gen_ca()
     public_data, private_data = _cert_key()
 
     builder = CertificateBuilder(
         {
-            "common_name": cn
+            "common_name": name
         },
         _load_public(public_data)
     )
     builder.issuer = _load_cert(ca_cert_data)
+    builder.subject_alt_domains = [name]
     cert = builder.build(_load_private(ca_private_data))
     return (
         _dump_cert(cert),


### PR DESCRIPTION
Modify the localhost test cert generation to add subjectAltNames to the certificates. 

Fixes #222. Related to #280.
