### PR TITLE
Update Haskell stub to LTS-7.2 and latest version of x509 package

### DIFF
--- a/stubs/haskell-http-client-tls/results.txt
+++ b/stubs/haskell-http-client-tls/results.txt
@@ -1,5 +1,5 @@
 platform: OS X 10.11.6
-runner: trytls 0.3.5 (CPython 2.7.12)
+runner: trytls 0.3.6 (CPython 2.7.12)
 stub: ./run.sh
  PASS protect against Apple's TLS vulnerability CVE-2014-1266 [reject www.ssllabs.com:10443]
       output: HandshakeFailed (Error_Protocol ("bad SignatureRSA for ecdhparams",True,HandshakeFailure))
@@ -7,10 +7,12 @@ stub: ./run.sh
       output: HandshakeFailed (Error_Packet_Parsing "handshake[HandshakeType_ServerKeyXchg]: parsing error: remaining bytes")
  FAIL protect against the Logjam attack [reject www.ssllabs.com:10445]
       output: 200 OK
- PASS protect against FREAK attack (test server 1) [reject cve.freakattack.com:443]
-      output: HandshakeFailed (Error_Packet_Parsing "handshake[HandshakeType_ServerKeyXchg]: parsing error: remaining bytes")
- PASS protect against FREAK attack (test server 2) [reject cve2.freakattack.com:443]
-      output: HandshakeFailed (Error_Packet_Parsing "handshake[HandshakeType_ServerKeyXchg]: parsing error: remaining bytes")
+ERROR protect against FREAK attack (test server 1) [reject cve.freakattack.com:443]
+      reason: stub exited with return code 1
+      output: test-http-client-tls: src/Main.hs:(56,15)-(59,28): Non-exhaustive patterns in lambda
+ERROR protect against FREAK attack (test server 2) [reject cve2.freakattack.com:443]
+      reason: stub exited with return code 1
+      output: test-http-client-tls: src/Main.hs:(56,15)-(59,28): Non-exhaustive patterns in lambda
  PASS protection against POODLE attack [reject sslv3.dshield.org:443]
       output: HandshakeFailed (Error_Protocol ("server version SSL3 is not supported",True,ProtocolVersion))
  PASS support for TLS server name indication (SNI) [accept badssl.com:443]
@@ -19,8 +21,8 @@ stub: ./run.sh
       output: HandshakeFailed (Error_Protocol ("certificate rejected: [SelfSigned]",True,CertificateUnknown))
  PASS expired certificate [reject expired.badssl.com:443]
       output: HandshakeFailed (Error_Protocol ("certificate has expired",True,CertificateExpired))
- FAIL wrong hostname in certificate [reject wrong.host.badssl.com:443]
-      output: 200 OK
+ PASS wrong hostname in certificate [reject wrong.host.badssl.com:443]
+      output: HandshakeFailed (Error_Protocol ("certificate rejected: [NameMismatch \"wrong.host.badssl.com\"]",True,CertificateUnknown))
  PASS SHA-256 signature [accept sha256.badssl.com:443]
       output: 200 OK
  PASS 1000 subjectAltNames [accept 1000-sans.badssl.com:443]
@@ -61,17 +63,17 @@ stub: ./run.sh
       output: 200 OK
  PASS expired certificate [reject expired.badtls.io:11006]
       output: HandshakeFailed (Error_Protocol ("certificate has expired",True,CertificateExpired))
- FAIL invalid wildcard certificate Common Name [reject wildcard.mismatch.badtls.io:11007]
-      output: 200 OK
+ PASS invalid wildcard certificate Common Name [reject wildcard.mismatch.badtls.io:11007]
+      output: HandshakeFailed (Error_Protocol ("certificate rejected: [NameMismatch \"wildcard.mismatch.badtls.io\"]",True,CertificateUnknown))
  FAIL denies use of RC4 ciphers (RFC7465) [reject rc4.badtls.io:11008]
       output: 200 OK
  FAIL denies use of MD5 signature algorithm (RFC6151) [reject weak-sig.badtls.io:11004]
       output: 200 OK
  FAIL denies use of RC4 with MD5 ciphers [reject rc4-md5.badtls.io:11009]
       output: 200 OK
- PASS valid localhost certificate [accept localhost:50354]
+ PASS valid localhost certificate [accept localhost:54997]
       output: 200 OK
- PASS invalid localhost certificate [reject localhost:50357]
+ PASS invalid localhost certificate [reject localhost:55000]
       output: HandshakeFailed (Error_Protocol ("certificate rejected: [NameMismatch \"localhost\"]",True,CertificateUnknown))
  PASS use only the given CA bundle, not system's [reject sha256.badssl.com:443]
       output: HandshakeFailed (Error_Protocol ("certificate has unknown CA",True,UnknownCa))

--- a/stubs/haskell-http-client-tls/stack.yaml
+++ b/stubs/haskell-http-client-tls/stack.yaml
@@ -1,11 +1,12 @@
-resolver: lts-6.14
+resolver: lts-7.2
 packages:
   - '.'
   - location:
-      git: https://github.com/oherrala/hs-certificate
-      commit: fccd483710e5a4f37368f03d839eca120523e324
+      git: https://github.com/vincenthz/hs-certificate
+      commit: 207d9fef631234df4303c9acb1519a2e4241b26f
     subdirs:
       - x509-store
+      - x509-validation
 extra-deps: []
 flags: {}
 extra-package-dbs: []


### PR DESCRIPTION
Two good things merged into x509 package worth mentioning:
- Certificate bundle reading was merged from pull request https://github.com/vincenthz/hs-certificate/pull/71
- Certificate name validation was merged from pull request https://github.com/vincenthz/hs-certificate/pull/75
