### PR TITLE
Remove sslv3.dshield.com and tlsfun.de tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ We are currently working to support the following [backends](backends/):
 * Local backend in the test runner itself (aka `localhost` backend)
 * [SSLLabs](https://ssllabs.com) - protection against
   [certain attacks](backends/ssllabs/README.md)
-* [freakattack.com](https://freakattack.com/) - protection against
-  [FREAK](https://mitls.org/pages/attacks/SMACK#freak)
 * [Trytls backend](backends/trytls) both as docker based
   "run-it-yourself" packaging and as a hosted service provided by us [WIP]
 

--- a/runners/trytls/bundles/https.py
+++ b/runners/trytls/bundles/https.py
@@ -89,17 +89,6 @@ def ssllabs(accept, port, description):
     )
 
 
-@testenv
-def tlsfun(accept, name, description, forced_result):
-    yield Test(
-        accept=accept,
-        description=description,
-        host=name + ".tlsfun.de",
-        port=443,
-        forced_result=forced_result
-    )
-
-
 @contextlib.contextmanager
 def http_server(ssl_context, host="localhost", port=0):
     class Timeout(Exception):
@@ -213,36 +202,6 @@ def badssl_tests():
         badssl(False, "dh512", "denies use of 512 bit Diffie-Hellman (DH)", forced_result)
     )
 
-
-@testgroup
-def tlsfun_tests():
-    forced_result = None
-
-    res = yield Test(
-        accept=True,
-        description="support for TLS server name indication (SNI) #2",
-        host="tlsfun.de",
-        port=443
-    )
-    if res.type != results.Pass:
-        forced_result = results.Skip("could not detect SNI support")
-
-    res = yield Test(
-        accept=False,
-        description="expired + self-signed certificate",
-        host="expired.tlsfun.de",
-        port=443,
-        forced_result=forced_result
-    )
-    if res.type != results.Pass and not forced_result:
-        forced_result = results.Skip("stub didn't reject an expired + self-signed certificate")
-
-    yield testgroup(
-        tlsfun(False, "badcert-edell", "eDellRoot CA #2", forced_result),
-        tlsfun(False, "superfish", "Superfish CA #2", forced_result)
-    )
-
-
 ssllabs_tests = testgroup(
     ssllabs(False, 10443, "protect against Apple's TLS vulnerability CVE-2014-1266"),
     ssllabs(False, 10444, "protect against the FREAK attack"),
@@ -275,7 +234,6 @@ local_tests = testgroup(
 all_tests = testgroup(
     ssllabs_tests,
     badssl_tests,
-    tlsfun_tests,
     badtls_tests,
     local_tests
 )

--- a/runners/trytls/bundles/https.py
+++ b/runners/trytls/bundles/https.py
@@ -272,18 +272,8 @@ local_tests = testgroup(
     badssl_onlymyca("use only the given CA bundle, not system's")
 )
 
-dshield_tests = testgroup(
-    Test(
-        accept=False,
-        description="protection against POODLE attack",
-        host="sslv3.dshield.org",
-        port=443
-    )
-)
-
 all_tests = testgroup(
     ssllabs_tests,
-    dshield_tests,
     badssl_tests,
     tlsfun_tests,
     badtls_tests,


### PR DESCRIPTION
This pull request removes the following tests:
- **sslv3.dshield.org** appears to be offline (see #297).
- **tlsfun.de** is a sanity check dependent on StartCom (see #296). Other providers (such as badssl.com and badtls.io) already offer similar tests to the ones we use from tlsfun.de.
- **expired.tlsfun.de** tests the same things as e.g. expired.badtls.io and self-signed.badssl.com.
- **badcert-edell.tlsfun.de** and **superfish.tlsfun.de** can be replaced with edellroot.badssl.com and superfish.badssl.com.

Closes #297. Closes #296.
