### PR TITLE
Updating the Haskell stub

### DIFF
--- a/stubs/haskell-http-client-tls/src/Main.hs
+++ b/stubs/haskell-http-client-tls/src/Main.hs
@@ -25,7 +25,7 @@ import           Network.TLS                (ClientParams, clientShared,
                                              clientSupported,
                                              defaultParamsClient, sharedCAStore,
                                              supportedCiphers)
-import           Network.TLS.Extra.Cipher   (ciphersuite_strong)
+import           Network.TLS.Extra.Cipher   (ciphersuite_default)
 
 main :: IO ()
 main = do
@@ -86,6 +86,6 @@ injectCA caBundle p =
 
 injectCiphers :: ClientParams -> ClientParams
 injectCiphers p =
-  p { clientSupported = supported { supportedCiphers = ciphersuite_strong } }
+  p { clientSupported = supported { supportedCiphers = ciphersuite_default } }
   where
     supported = clientSupported p

--- a/stubs/haskell-http-client-tls/src/Main.hs
+++ b/stubs/haskell-http-client-tls/src/Main.hs
@@ -8,7 +8,9 @@ import           Data.ByteString.Char8      (unpack)
 import           System.Environment         (getArgs, getProgName)
 import           System.Exit                (exitFailure, exitSuccess)
 
-import           Network.HTTP.Client        (HttpException (..), httpLbs,
+import           Network.HTTP.Client        (HttpException (..),
+                                             HttpExceptionContent(..),
+                                             httpLbs,
                                              newManager, parseRequest,
                                              responseStatus)
 import           Network.HTTP.Client.TLS    (mkManagerSettings)
@@ -23,7 +25,7 @@ import           Network.TLS                (ClientParams, clientShared,
                                              clientSupported,
                                              defaultParamsClient, sharedCAStore,
                                              supportedCiphers)
-import           Network.TLS.Extra.Cipher   (ciphersuite_all)
+import           Network.TLS.Extra.Cipher   (ciphersuite_strong)
 
 main :: IO ()
 main = do
@@ -54,7 +56,7 @@ main = do
 
   _ <- catch (doGet request manager)
              (\exp' -> case exp' of
-               TlsExceptionHostPort e _ _ -> do
+               HttpExceptionRequest _req (InternalException e) -> do
                  print e
                  putStrLn "REJECT"
                  exitSuccess
@@ -84,6 +86,6 @@ injectCA caBundle p =
 
 injectCiphers :: ClientParams -> ClientParams
 injectCiphers p =
-  p { clientSupported = supported { supportedCiphers = ciphersuite_all } }
+  p { clientSupported = supported { supportedCiphers = ciphersuite_strong } }
   where
     supported = clientSupported p

--- a/stubs/haskell-http-client-tls/stack.yaml
+++ b/stubs/haskell-http-client-tls/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-7.15
+resolver: lts-12.17

--- a/stubs/haskell-http-client-tls/stack.yaml
+++ b/stubs/haskell-http-client-tls/stack.yaml
@@ -1,1 +1,4 @@
 resolver: lts-12.17
+packages:
+- .
+- /Users/kazu/work/hs-tls/core

--- a/stubs/haskell-http-client-tls/test-http-client-tls.cabal
+++ b/stubs/haskell-http-client-tls/test-http-client-tls.cabal
@@ -20,7 +20,7 @@ executable test-http-client-tls
   build-depends:       base >= 4.7 && < 5
                      , bytestring
                      , connection
-                     , http-client
+                     , http-client >= 0.5
                      , http-client-tls
                      , http-types
                      , tls


### PR DESCRIPTION
This patch updates the Haskell stub:
- Using LTS 12.17 (the latest one) for Stackage
- Using `http-client` >= 0.5 (the current one), which does not provide `TlsExceptionHostPort`
- Using `ciphersuite_strong` instead of deprecated `ciphersuite_all` from Haskell TLS

The author of `http-client` has already checked if this fix is correct.
And note that I'm one of maintainers of Haskell TLS.

Thank you for creating a wonderful test tool!