### PR TITLE
bug: fix Python 3.8+ linux compat.

### DIFF
--- a/runners/trytls/utils.py
+++ b/runners/trytls/utils.py
@@ -3,7 +3,6 @@ from __future__ import print_function, unicode_literals
 import os
 import sys
 import shutil
-import platform
 import tempfile
 import functools
 import contextlib
@@ -15,6 +14,17 @@ except ImportError:
     # for Python 2.7.
     from pipes import quote as _quote
 
+# Python 3.8+ removed platform.linux_distribution(). The 'distro' module
+# can be used as a replacement, but only on Linux, so we catch ImportError
+# and act accordingly.
+# See https://stackoverflow.com/a/64106589/715524
+import platform
+using_distro = False
+try:
+    import distro
+    using_distro = True
+except ImportError:
+    pass
 
 def format_command(args):
     r"""
@@ -42,12 +52,17 @@ def platform_info():
     """
 
     if sys.platform.startswith("linux"):
-        distname, version, _ = platform.linux_distribution()
-        if not distname:
-            return "Linux"
-        if not version:
-            return "Linux ({})".format(distname)
-        return "Linux ({} {})".format(distname, version)
+        if not using_distro:
+            distname, version, _ = platform.linux_distribution()
+            if not distname:
+                return "Linux"
+            if not version:
+                return "Linux ({})".format(distname)
+            return "Linux ({} {})".format(distname, version)
+        else:
+            distname = distro.name()
+            version = distro.version()
+            return "Linux ({} {})".format(distname, version)
     elif sys.platform == "darwin":
         version, _, _ = platform.mac_ver()
         if version.startswith("10."):

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,18 @@ if sys.version_info < py_required:
         format_version(sys.version_info)
     ))
 
+
+install_requires=[
+    "colorama",
+    "oscrypto",
+    "certbuilder"
+]
+
+# Python 3.8 removed the deprecated `platform.linux_distribution` function,
+# recommending use of the 'distro' module for this purpose.
+if sys.version_info > (3, 8, 0):
+    install_requires.extend(["distro"])
+
 # Import the local version of the package
 found = imp.find_module("trytls", [os.path.join(os.path.dirname(__file__), "runners")])
 trytls = imp.load_module("trytls", *found)
@@ -42,9 +54,5 @@ setup(
             "json=trytls.formatters.json:formatter"
         ]
     },
-    install_requires=[
-        "colorama",
-        "oscrypto",
-        "certbuilder"
-    ]
+    install_requires=install_requires
 )


### PR DESCRIPTION
Prior to this commit the `runners/trytls/utils.py` script would fail to execute on Python 3.8+ systems. This is because the deprecated [`platform.linux_distribution` func](https://docs.python.org/3.7/library/platform.html#platform.linux_distribution) used by this script was removed in Python 3.8.

This commit updates the script to try to conditionally use the [`distro` module](https://pypi.org/project/distro/) as a replacement. The `setup.py` script is updated to conditionally require this dependency on systems using Python 3.8+.

This change is sufficient to get trytls working on my Python 3.10 system.
